### PR TITLE
Introduce a `PThreadExecutor`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+xcode_trim_whitespace_on_empty_lines = true
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,4 +1,5 @@
 .gitignore
+.editorconfig
 *.md
 *.txt
 *.yml

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,36 @@
+
+                            The SwiftPlatformExecutors Project
+                            ====================
+
+Please visit the SwiftPlatformExecutors web site for more information:
+
+  * https://github.com/swiftlang/swift-platform-executors
+
+Copyright 2025 The SwiftPlatformExecutors Project
+
+The SwiftPlatformExecutors Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+Also, please refer to each LICENSE.<component>.txt file, which is located in
+the 'license' directory of the distribution file, for the license terms of the
+components that this product depends on.
+
+-------------------------------------------------------------------------------
+
+This product contains a derivation of SwiftNIO's `Thread`, `SelectableEventLoop` and `Selector`.
+
+  * LICENSE (Apache License 2.0):
+    * https://github.com/apple/swift-nio/blob/main/LICENSE.txt
+  * HOMEPAGE:
+    * https://github.com/apple/swift-nio
+
+---

--- a/Package.swift
+++ b/Package.swift
@@ -7,16 +7,42 @@ let package = Package(
     .library(
       name: "Win32NativeExecutors",
       targets: ["Win32NativeExecutors"]
-    )
+    ),
+    .library(
+      name: "PThreadExecutors",
+      targets: ["PThreadExecutors"]
+    ),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0")
   ],
   targets: [
     .target(
       name: "Win32NativeExecutors"
     ),
+    .target(
+      name: "PThreadExecutors",
+      dependencies: [
+        .product(name: "DequeModule", package: "swift-collections"),
+        .target(name: "CPThreadExecutors"),
+      ]
+    ),
+    .target(
+      name: "CPThreadExecutors",
+      cSettings: [
+        .define("_GNU_SOURCE")
+      ]
+    ),
     .testTarget(
       name: "Win32NativeExecutorsTests",
       dependencies: [
         "Win32NativeExecutors"
+      ]
+    ),
+    .testTarget(
+      name: "PThreadExecutorsTests",
+      dependencies: [
+        "PThreadExecutors"
       ]
     ),
   ]

--- a/Sources/CPThreadExecutors/include/CPThreadExecutors.h
+++ b/Sources/CPThreadExecutors/include/CPThreadExecutors.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef C_PTHREAD_EXECUTORS_LINUX_H
+#define C_PTHREAD_EXECUTORS_LINUX_H
+
+#ifdef __linux__
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <pthread.h>
+#include <errno.h>
+
+int CPThreadExecutors_pthread_setname_np(pthread_t thread, const char *name);
+int CPThreadExecutors_pthread_getname_np(pthread_t thread, char *name, size_t len);
+
+#endif
+#endif

--- a/Sources/CPThreadExecutors/shim.c
+++ b/Sources/CPThreadExecutors/shim.c
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __linux__
+
+#include <CPThreadExecutors.h>
+#include <pthread.h>
+
+int CPThreadExecutors_pthread_setname_np(pthread_t thread, const char *name) {
+    return pthread_setname_np(thread, name);
+}
+
+int CPThreadExecutors_pthread_getname_np(pthread_t thread, char *name, size_t len) {
+#ifdef __ANDROID__
+    // https://android.googlesource.com/platform/bionic/+/8a18af52d9b9344497758ed04907a314a083b204/libc/bionic/pthread_setname_np.cpp#51
+    if (thread == pthread_self()) {
+        return TEMP_FAILURE_RETRY(prctl(PR_GET_NAME, name)) == -1 ? -1 : 0;
+    }
+
+    char comm_name[64];
+    snprintf(comm_name, sizeof(comm_name), "/proc/self/task/%d/comm", pthread_gettid_np(thread));
+    int fd = TEMP_FAILURE_RETRY(open(comm_name, O_CLOEXEC | O_RDONLY));
+
+    if (fd == -1) return -1;
+
+    ssize_t n = TEMP_FAILURE_RETRY(read(fd, name, len));
+    close(fd);
+    if (n == -1) return -1;
+
+    // The kernel adds a trailing '\n' to the /proc file,
+    // so this is actually the normal case for short names.
+    if (n > 0 && name[n - 1] == '\n') {
+        name[n - 1] = '\0';
+        return 0;
+    }
+
+    if (n >= 0 && len <= SSIZE_MAX && n == (ssize_t)len) return 1;
+
+    name[n] = '\0';
+    return 0;
+#else
+    return pthread_getname_np(thread, name, len);
+#endif
+}
+#endif

--- a/Sources/PThreadExecutors/Internal/Box.swift
+++ b/Sources/PThreadExecutors/Internal/Box.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Allows to "box" another value.
+final class Box<T> {
+  let value: T
+  init(_ value: T) { self.value = value }
+}

--- a/Sources/PThreadExecutors/Internal/ConditionLock.swift
+++ b/Sources/PThreadExecutors/Internal/ConditionLock.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif os(Windows)
+import ucrt
+import WinSDK
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("The concurrency lock module was unable to identify your C library.")
+#endif
+
+struct ConditionVariable<Value: ~Copyable>: ~Copyable {
+  #if os(Windows)
+  typealias LockType = SRWLOCK
+  typealias ConditionVariableType = CONDITION_VARIABLE
+  #elseif os(FreeBSD) || os(OpenBSD)
+  typealias LockType = pthread_mutex_t?
+  typealias ConditionVariableType = pthread_cond_t?
+  #else
+  typealias LockType = pthread_mutex_t
+  typealias ConditionVariableType = pthread_cond_t
+  #endif
+
+  private nonisolated(unsafe) var state: Value
+  private nonisolated(unsafe) let lock = UnsafeMutablePointer<LockType>.allocate(capacity: 1)
+  private nonisolated(unsafe) let condition = UnsafeMutablePointer<ConditionVariableType>.allocate(capacity: 1)
+
+  init(_ state: consuming sending Value) {
+    self.state = state
+    #if os(Windows)
+    InitializeSRWLock(lock)
+    InitializeConditionVariable(condition)
+    #else
+    pthread_mutex_init(lock, nil)
+    pthread_cond_init(condition, nil)
+    #endif
+  }
+
+  private func _lock() {
+    #if os(Windows)
+    AcquireSRWLockExclusive(lock)
+    #else
+    pthread_mutex_lock(lock)
+    #endif
+  }
+
+  private func _unlock() {
+    #if os(Windows)
+    ReleaseSRWLockExclusive(lock)
+    #else
+    pthread_mutex_unlock(lock)
+    #endif
+  }
+
+  private func _signal() {
+    #if os(Windows)
+    WakeConditionVariable(condition)
+    #else
+    pthread_cond_signal(condition)
+    #endif
+  }
+
+  private func _signalAll() {
+    #if os(Windows)
+    WakeAllConditionVariable(condition)
+    #else
+    pthread_cond_broadcast(condition)
+    #endif
+  }
+
+  private func _wait() {
+    #if os(Windows)
+    SleepConditionVariableSRW(condition, lock, INFINITE, 0)
+    #else
+    pthread_cond_wait(condition, lock)
+    #endif
+  }
+
+  mutating func signal<Return, Failure: Error>(
+    block: (inout sending Value) throws(Failure) -> Return
+  ) throws(Failure) -> Return {
+    self._lock()
+    defer {
+      self._unlock()
+    }
+    defer {
+      self._signal()
+    }
+    return try block(&state)
+  }
+
+  mutating func signalAll<Return, Failure: Error>(
+    block: (inout sending Value) throws(Failure) -> Return
+  ) throws(Failure) -> Return {
+    self._lock()
+    defer {
+      self._unlock()
+    }
+    defer {
+      self._signalAll()
+    }
+    return try block(&state)
+  }
+
+  mutating func wait<Return, Failure: Error>(
+    block: (inout sending Value) throws(Failure) -> Return
+  ) throws(Failure) -> Return {
+    try self.wait(when: { _ in true }, block: block)
+  }
+
+  mutating func wait<Return, Failure: Error>(
+    when: (inout sending Value) -> Bool,
+    block: (inout sending Value) throws(Failure) -> Return
+  ) throws(Failure) -> Return {
+    self._lock()
+    defer {
+      self._unlock()
+    }
+    while true {
+      if when(&state) {
+        break
+      }
+      self._wait()
+    }
+    return try block(&state)
+  }
+}

--- a/Sources/PThreadExecutors/Internal/PThread.swift
+++ b/Sources/PThreadExecutors/Internal/PThread.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+
+#if os(Linux) || os(Android)
+import CPThreadExecutors
+
+private let sys_pthread_getname_np = CPThreadExecutors_pthread_getname_np
+private let sys_pthread_setname_np = CPThreadExecutors_pthread_setname_np
+#if os(Android)
+private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
+#else
+private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer?
+#endif
+#elseif canImport(Darwin)
+import Darwin
+
+private let sys_pthread_getname_np = pthread_getname_np
+// Emulate the same method signature as pthread_setname_np on Linux.
+private func sys_pthread_setname_np(
+  _ p: pthread_t,
+  _ pointer: UnsafePointer<Int8>
+) -> Int32 {
+  assert(pthread_equal(pthread_self(), p) != 0)
+  pthread_setname_np(pointer)
+  // Will never fail on macOS so just return 0 which will be used on linux to signal it not failed.
+  return 0
+}
+private typealias ThreadDestructor = @convention(c) (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer?
+
+#endif
+
+private func sysPthread_create(
+  handle: UnsafeMutablePointer<pthread_t?>,
+  destructor: @escaping ThreadDestructor,
+  args: UnsafeMutableRawPointer?
+) -> CInt {
+  #if canImport(Darwin)
+  return pthread_create(handle, nil, destructor, args)
+  #else
+  #if canImport(Musl)
+  var handleLinux: OpaquePointer? = nil
+  let result = pthread_create(
+    &handleLinux,
+    nil,
+    destructor,
+    args
+  )
+  #else
+  var handleLinux = pthread_t()
+  let result = pthread_create(
+    &handleLinux,
+    nil,
+    destructor,
+    args
+  )
+  #endif
+  handle.pointee = handleLinux
+  return result
+  #endif
+}
+
+enum PThread {
+  typealias ThreadHandle = pthread_t
+  typealias ThreadSpecificKey = pthread_key_t
+  #if canImport(Darwin)
+  typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer) -> Void
+  #else
+  typealias ThreadSpecificKeyDestructor = @convention(c) (UnsafeMutableRawPointer?) -> Void
+  #endif
+
+  static func threadName(_ thread: PThread.ThreadHandle) -> String? {
+    // 64 bytes should be good enough as on Linux the limit is usually 16
+    // and it's very unlikely a user will ever set something longer
+    // anyway.
+    var chars: [CChar] = Array(repeating: 0, count: 64)
+    return chars.withUnsafeMutableBufferPointer { ptr in
+      guard sys_pthread_getname_np(thread, ptr.baseAddress!, ptr.count) == 0 else {
+        return nil
+      }
+
+      let buffer: UnsafeRawBufferPointer =
+        UnsafeRawBufferPointer(UnsafeBufferPointer<CChar>(rebasing: ptr.prefix { $0 != 0 }))
+      return String(decoding: buffer, as: Unicode.UTF8.self)
+    }
+  }
+
+  static func run(
+    handle: inout PThread.ThreadHandle?,
+    args: Box<Thread.ThreadBoxValue>
+  ) {
+    let argv0 = Unmanaged.passRetained(args).toOpaque()
+    let res = sysPthread_create(
+      handle: &handle,
+      destructor: {
+        // Cast to UnsafeMutableRawPointer? and force unwrap to make the
+        // same code work on macOS and Linux.
+        let boxed = Unmanaged<Thread.ThreadBox>
+          .fromOpaque(($0 as UnsafeMutableRawPointer?)!)
+          .takeRetainedValue()
+        let (body, name) = (boxed.value.body, boxed.value.name)
+        let hThread: PThread.ThreadHandle = pthread_self()
+
+        if let name = name {
+          let maximumThreadNameLength: Int
+          #if os(Linux) || os(Android)
+          maximumThreadNameLength = 15
+          #else
+          maximumThreadNameLength = .max
+          #endif
+          name.prefix(maximumThreadNameLength).withCString { namePtr in
+            // this is non-critical so we ignore the result here, we've seen
+            // EPERM in containers.
+            _ = sys_pthread_setname_np(hThread, namePtr)
+          }
+        }
+
+        body(Thread(handle: hThread, desiredName: name))
+
+        #if os(Android)
+        return UnsafeMutableRawPointer(bitPattern: 0xdeadbee)!
+        #else
+        return nil
+        #endif
+      },
+      args: argv0
+    )
+    precondition(res == 0, "Unable to create thread: \(res)")
+  }
+
+  static func isCurrentThread(_ thread: PThread.ThreadHandle) -> Bool {
+    return pthread_equal(thread, pthread_self()) != 0
+  }
+
+  static var currentThread: PThread.ThreadHandle {
+    return pthread_self()
+  }
+
+  static func compareThreads(_ lhs: PThread.ThreadHandle, _ rhs: PThread.ThreadHandle) -> Bool {
+    return pthread_equal(lhs, rhs) != 0
+  }
+}
+
+#endif

--- a/Sources/PThreadExecutors/Internal/Selector/EpollSelector.swift
+++ b/Sources/PThreadExecutors/Internal/Selector/EpollSelector.swift
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Glibc)
+import Glibc
+import CPThreadExecutors
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+struct EpollSelector {
+  fileprivate let myThread: Thread
+  fileprivate var selectorFD: CInt
+  fileprivate let eventFD: CInt
+
+  init() throws {
+    self.myThread = Thread.current
+    self.selectorFD = try Epoll.epoll_create(size: 128)
+    self.eventFD = try EventFileDescriptor.makeEventFileDescriptor(
+      initval: 0,
+      flags: Int32(EventFileDescriptor.EFD_CLOEXEC | EventFileDescriptor.EFD_NONBLOCK)
+    )
+
+    var ev = Epoll.epoll_event()
+    ev.events = Epoll.EPOLLERR | Epoll.EPOLLHUP | Epoll.EPOLLIN
+    try Epoll.epoll_ctl(
+      epfd: self.selectorFD,
+      op: Epoll.EPOLL_CTL_ADD,
+      fd: self.eventFD,
+      event: &ev
+    )
+  }
+
+  /// Blocks until the wakeup is called.
+  func whenReady(
+    strategy: SelectorStrategy
+  ) throws {
+    assert(self.myThread == Thread.current)
+
+    _ = try withUnsafeTemporaryAllocation(of: Epoll.epoll_event.self, capacity: 1) { bufferPointer in
+      try Epoll.epoll_wait(
+        epfd: self.selectorFD,
+        events: bufferPointer.baseAddress!,
+        maxevents: 1,
+        timeout: -1  // Specifying -1 blocks until a file descriptor becomes ready
+      )
+    }
+
+    // Consume event
+    var val = EventFileDescriptor.eventfd_t()
+    _ = try EventFileDescriptor.eventfd_read(fd: self.eventFD, value: &val)
+  }
+
+  /// Wakes up the selector.
+  func wakeup() throws {
+    assert(Thread.current != self.myThread)
+    _ = try EventFileDescriptor.eventfd_write(fd: self.eventFD, value: 1)
+  }
+
+  @inline(never)
+  internal static func eventfd_write(fd: CInt, value: UInt64) throws -> CInt {
+    return try syscall(blocking: false) {
+      CPThreadExecutors.eventfd_write(fd, value)
+    }.result
+  }
+}
+
+internal enum Epoll {
+  internal typealias epoll_event = CPThreadExecutors.epoll_event
+
+  internal static let EPOLL_CTL_ADD: CInt = numericCast(CPThreadExecutors.EPOLL_CTL_ADD)
+  internal static let EPOLL_CTL_MOD: CInt = numericCast(CPThreadExecutors.EPOLL_CTL_MOD)
+  internal static let EPOLL_CTL_DEL: CInt = numericCast(CPThreadExecutors.EPOLL_CTL_DEL)
+
+  #if os(Android)
+  internal static let EPOLLIN: CUnsignedInt = 1  //numericCast(EPOLLIN)
+  internal static let EPOLLOUT: CUnsignedInt = 4  //numericCast(EPOLLOUT)
+  internal static let EPOLLERR: CUnsignedInt = 8  // numericCast(EPOLLERR)
+  internal static let EPOLLRDHUP: CUnsignedInt = 8192  //numericCast(EPOLLRDHUP)
+  internal static let EPOLLHUP: CUnsignedInt = 16  //numericCast(EPOLLHUP)
+  internal static let EPOLLET: CUnsignedInt = 2_147_483_648  //numericCast(EPOLLET)
+  #elseif canImport(Musl)
+  internal static let EPOLLIN: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLIN)
+  internal static let EPOLLOUT: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLOUT)
+  internal static let EPOLLERR: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLERR)
+  internal static let EPOLLRDHUP: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLRDHUP)
+  internal static let EPOLLHUP: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLHUP)
+  internal static let EPOLLET: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLET)
+  #else
+  internal static let EPOLLIN: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLIN.rawValue)
+  internal static let EPOLLOUT: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLOUT.rawValue)
+  internal static let EPOLLERR: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLERR.rawValue)
+  internal static let EPOLLRDHUP: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLRDHUP.rawValue)
+  internal static let EPOLLHUP: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLHUP.rawValue)
+  internal static let EPOLLET: CUnsignedInt = numericCast(CPThreadExecutors.EPOLLET.rawValue)
+  #endif
+
+  internal static let ENOENT: CUnsignedInt = numericCast(CPThreadExecutors.ENOENT)
+
+  @inline(never)
+  internal static func epoll_create(size: CInt) throws -> CInt {
+    return try syscall(blocking: false) {
+      CPThreadExecutors.epoll_create(size)
+    }.result
+  }
+
+  @inline(never)
+  @discardableResult
+  internal static func epoll_ctl(
+    epfd: CInt,
+    op: CInt,
+    fd: CInt,
+    event: UnsafeMutablePointer<epoll_event>
+  ) throws -> CInt {
+    return try syscall(blocking: false) {
+      CPThreadExecutors.epoll_ctl(epfd, op, fd, event)
+    }.result
+  }
+
+  @inline(never)
+  internal static func epoll_wait(
+    epfd: CInt,
+    events: UnsafeMutablePointer<epoll_event>,
+    maxevents: CInt,
+    timeout: CInt
+  ) throws -> CInt {
+    return try syscall(blocking: false) {
+      CPThreadExecutors.epoll_wait(epfd, events, maxevents, timeout)
+    }.result
+  }
+}
+
+private enum EventFileDescriptor {
+  fileprivate static let EFD_CLOEXEC = CPThreadExecutors.EFD_CLOEXEC
+  fileprivate static let EFD_NONBLOCK = CPThreadExecutors.EFD_NONBLOCK
+  fileprivate typealias eventfd_t = CPThreadExecutors.eventfd_t
+
+  @inline(never)
+  fileprivate static func eventfd_read(fd: CInt, value: UnsafeMutablePointer<UInt64>) throws -> CInt {
+    return try syscall(blocking: false) {
+      CPThreadExecutors.eventfd_read(fd, value)
+    }.result
+  }
+
+  @inline(never)
+  internal static func eventfd_write(fd: CInt, value: UInt64) throws -> CInt {
+    return try syscall(blocking: false) {
+      CPThreadExecutors.eventfd_write(fd, value)
+    }.result
+  }
+
+  @inline(never)
+  fileprivate static func makeEventFileDescriptor(initval: CUnsignedInt, flags: CInt) throws -> CInt {
+    return try syscall(blocking: false) {
+      // Note: Please do _not_ remove the `numericCast`, this is to allow compilation in Ubuntu 14.04 and
+      // other Linux distros which ship a glibc from before this commit:
+      // https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=69eb9a183c19e8739065e430758e4d3a2c5e4f1a
+      // which changes the first argument from `CInt` to `CUnsignedInt` (from Sat, 20 Sep 2014).
+      CPThreadExecutors.eventfd(numericCast(initval), flags)
+    }.result
+  }
+}
+
+private struct EpollFilterSet: OptionSet, Equatable {
+  typealias RawValue = UInt8
+
+  let rawValue: RawValue
+
+  static let _none = EpollFilterSet([])
+  static let hangup = EpollFilterSet(rawValue: 1 << 0)
+  static let readHangup = EpollFilterSet(rawValue: 1 << 1)
+  static let input = EpollFilterSet(rawValue: 1 << 2)
+  static let output = EpollFilterSet(rawValue: 1 << 3)
+  static let error = EpollFilterSet(rawValue: 1 << 4)
+
+  init(rawValue: RawValue) {
+    self.rawValue = rawValue
+  }
+}
+#endif

--- a/Sources/PThreadExecutors/Internal/Selector/KQueueSelector.swift
+++ b/Sources/PThreadExecutors/Internal/Selector/KQueueSelector.swift
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+
+private let sysKevent = kevent
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+struct KQueueSelector {
+  fileprivate let myThread: Thread
+  fileprivate var selectorFD: CInt
+
+  init() throws {
+    self.myThread = Thread.current
+    self.selectorFD = try Self.kqueue()
+
+    var event = Darwin.kevent()
+    event.ident = 0
+    event.filter = Int16(EVFILT_USER)
+    event.fflags = UInt32(NOTE_FFNOP)
+    event.data = 0
+    event.udata = nil
+    event.flags = UInt16(EV_ADD | EV_ENABLE | EV_CLEAR)
+    try withUnsafeMutablePointer(to: &event) { ptr in
+      try Self.kqueueApplyEventChangeSet(
+        selectorFD: selectorFD,
+        keventBuffer: UnsafeMutableBufferPointer(start: ptr, count: 1)
+      )
+    }
+  }
+
+  @inline(never)
+  fileprivate static func kqueue() throws -> CInt {
+    return try syscall(blocking: false) {
+      Darwin.kqueue()
+    }.result
+  }
+
+  @inline(never)
+  @discardableResult
+  fileprivate static func kevent(
+    kq: CInt,
+    changelist: UnsafePointer<kevent>?,
+    nchanges: CInt,
+    eventlist: UnsafeMutablePointer<kevent>?,
+    nevents: CInt,
+    timeout: UnsafePointer<Darwin.timespec>?
+  ) throws -> CInt {
+    return try syscall(blocking: false) {
+      sysKevent(kq, changelist, nchanges, eventlist, nevents, timeout)
+    }.result
+  }
+
+  /// Apply a kqueue changeset by calling the `kevent` function with the `kevent`s supplied in `keventBuffer`.
+  private static func kqueueApplyEventChangeSet(
+    selectorFD: CInt,
+    keventBuffer: UnsafeMutableBufferPointer<kevent>
+  ) throws {
+    guard keventBuffer.count > 0 else {
+      // nothing to do
+      return
+    }
+    do {
+      try Self.kevent(
+        kq: selectorFD,
+        changelist: keventBuffer.baseAddress!,
+        nchanges: CInt(keventBuffer.count),
+        eventlist: nil,
+        nevents: 0,
+        timeout: nil
+      )
+    } catch let err as IOError {
+      if err.errnoCode == EINTR {
+        // See https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
+        // When kevent() call fails with EINTR error, all changes in the changelist have been applied.
+        return
+      }
+      throw err
+    }
+  }
+
+  private static func toKQueueTimeSpec(strategy: SelectorStrategy) -> timespec? {
+    switch strategy {
+    case .block:
+      return nil
+    case .now:
+      return timespec(tv_sec: 0, tv_nsec: 0)
+    }
+  }
+
+  /// Blocks until the wakeup is called.
+  func whenReady(
+    strategy: SelectorStrategy
+  ) throws {
+    let timespec = Self.toKQueueTimeSpec(strategy: strategy)
+    _ = try timespec.withUnsafeOptionalPointer { ts in
+      Int(
+        try Self.kevent(
+          kq: self.selectorFD,
+          changelist: nil,
+          nchanges: 0,
+          eventlist: nil,
+          nevents: 0,
+          timeout: ts
+        )
+      )
+    }
+  }
+
+  /// Wakes up the selector.
+  func wakeup() throws {
+    var event = Darwin.kevent()
+    event.ident = 0
+    event.filter = Int16(EVFILT_USER)
+    event.fflags = UInt32(NOTE_TRIGGER | NOTE_FFNOP)
+    event.data = 0
+    event.udata = nil
+    event.flags = 0
+    try withUnsafeMutablePointer(to: &event) { ptr in
+      try Self.kqueueApplyEventChangeSet(
+        selectorFD: self.selectorFD,
+        keventBuffer: UnsafeMutableBufferPointer(start: ptr, count: 1)
+      )
+    }
+  }
+}
+
+extension Optional {
+  fileprivate func withUnsafeOptionalPointer<T>(
+    _ body: (UnsafePointer<Wrapped>?) throws -> T
+  ) rethrows -> T {
+    guard var this = self else {
+      return try body(nil)
+    }
+    return try withUnsafePointer(to: &this) { x in
+      try body(x)
+    }
+  }
+}
+#endif

--- a/Sources/PThreadExecutors/Internal/Selector/SelectorStrategy.swift
+++ b/Sources/PThreadExecutors/Internal/Selector/SelectorStrategy.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// The strategy used for the `Selector`.
+enum SelectorStrategy {
+  /// Block until there is some IO ready to be processed or the `Selector` is explicitly woken up.
+  case block
+
+  /// Try to select all ready IO at this point in time without blocking at all.
+  case now
+}

--- a/Sources/PThreadExecutors/Internal/Selector/syscall.swift
+++ b/Sources/PThreadExecutors/Internal/Selector/syscall.swift
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Darwin)
+import Darwin
+#else
+#error("The IO module was unable to identify your C library.")
+#endif
+
+/// An result for an IO operation that was done on a non-blocking resource.
+enum IOResult<T: Equatable>: Equatable {
+  /// Signals that the IO operation could not be completed as otherwise we would need to block.
+  case wouldBlock(T)
+
+  /// Signals that the IO operation was completed.
+  case processed(T)
+}
+
+extension IOResult where T: FixedWidthInteger {
+  var result: T {
+    switch self {
+    case .processed(let value):
+      return value
+    case .wouldBlock(_):
+      fatalError("cannot unwrap IOResult")
+    }
+  }
+}
+
+/// An `Error` for an IO operation.
+struct IOError: Error, CustomStringConvertible {
+  let description: String
+
+  private enum Error {
+    #if os(Windows)
+    case windows(DWORD)
+    case winsock(CInt)
+    #endif
+    case errno(CInt)
+  }
+
+  private let error: Error
+
+  /// The `errno` that was set for the operation.
+  var errnoCode: CInt {
+    switch self.error {
+    case .errno(let code):
+      return code
+    }
+  }
+
+  /// Creates a new `IOError``
+  ///
+  /// - parameters:
+  ///     - errorCode: the `errno` that was set for the operation.
+  ///     - reason: the actual reason (in an human-readable form).
+  init(errnoCode code: CInt, reason: String) {
+    self.error = .errno(code)
+    self.description = reason
+  }
+}
+
+@inline(__always)
+@discardableResult
+internal func syscall<T: FixedWidthInteger>(
+  blocking: Bool,
+  where function: String = #function,
+  _ body: () throws -> T
+) throws -> IOResult<T> {
+  while true {
+    let res = try body()
+    if res == -1 {
+      #if os(Windows)
+      var err: CInt = 0
+      _get_errno(&err)
+      #else
+      let err = errno
+      #endif
+      print("errno", err)
+      switch (err, blocking) {
+      case (EINTR, _):
+        continue
+      case (EWOULDBLOCK, true):
+        return .wouldBlock(0)
+      default:
+        preconditionIsNotUnacceptableErrno(err: err, where: function)
+        throw IOError(errnoCode: err, reason: function)
+      }
+    }
+    return .processed(res)
+  }
+}
+
+private func preconditionIsNotUnacceptableErrno(err: CInt, where function: String) {
+  // strerror is documented to return "Unknown error: ..." for illegal value so it won't ever fail
+  #if os(Windows)
+  precondition(!isUnacceptableErrno(err), "unacceptable errno \(err) \(strerror(err)) in \(function))")
+  #else
+  precondition(
+    !isUnacceptableErrno(err),
+    "unacceptable errno \(err) \(String(cString: strerror(err)!)) in \(function))"
+  )
+  #endif
+}
+
+private func isUnacceptableErrno(_ code: Int32) -> Bool {
+  // On iOS, EBADF is a possible result when a file descriptor has been reaped in the background.
+  // In particular, it's possible to get EBADF from accept(), where the underlying accept() FD
+  // is valid but the accepted one is not. The right solution here is to perform a check for
+  // SO_ISDEFUNCT when we see this happen, but we haven't yet invested the time to do that.
+  // In the meantime, we just tolerate EBADF on iOS.
+  #if canImport(Darwin) && !os(macOS)
+  switch code {
+  case EFAULT:
+    return true
+  default:
+    return false
+  }
+  #else
+  switch code {
+  case EFAULT, EBADF:
+    return true
+  default:
+    return false
+  }
+  #endif
+}

--- a/Sources/PThreadExecutors/Internal/Thread.swift
+++ b/Sources/PThreadExecutors/Internal/Thread.swift
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux) || os(FreeBSD) || os(Android)
+import CPThreadExecutors
+#endif
+
+final class Thread {
+  internal typealias ThreadBoxValue = (body: (Thread) -> Void, name: String?)
+  internal typealias ThreadBox = Box<ThreadBoxValue>
+
+  private let desiredName: String?
+
+  /// The thread handle used by this instance.
+  private let handle: PThread.ThreadHandle
+
+  /// Create a new instance
+  ///
+  /// - arguments:
+  ///     - handle: The `ThreadOpsSystem.ThreadHandle` that is wrapped and used by the `Thread`.
+  internal init(handle: PThread.ThreadHandle, desiredName: String?) {
+    self.handle = handle
+    self.desiredName = desiredName
+  }
+
+  /// Execute the given body with the `pthread_t` that is used by this `Thread` as argument.
+  ///
+  /// - warning: Do not escape `pthread_t` from the closure for later use.
+  ///
+  /// - parameters:
+  ///     - body: The closure that will accept the `pthread_t`.
+  /// - returns: The value returned by `body`.
+  internal func withUnsafeThreadHandle<Return, Failure: Error>(
+    body: (PThread.ThreadHandle) throws(Failure) -> Return
+  ) throws(Failure) -> Return {
+    return try body(self.handle)
+  }
+
+  /// Get current name of the `Thread` or `nil` if not set.
+  var currentName: String? {
+    return PThread.threadName(self.handle)
+  }
+
+  /// Spawns and runs some task in a `Thread`.
+  ///
+  /// - arguments:
+  ///     - name: The name of the `Thread` or `nil` if no specific name should be set.
+  ///     - body: The function to execute within the spawned `Thread`.
+  ///     - detach: Whether to detach the thread. If the thread is not detached it must be `join`ed.
+  static func spawnAndRun(
+    name: String? = nil,
+    body: @escaping (Thread) -> Void
+  ) {
+    var handle: PThread.ThreadHandle? = nil
+
+    // Store everything we want to pass into the c function in a Box so we
+    // can hand-over the reference.
+    let tuple: ThreadBoxValue = (body: body, name: name)
+    let box = ThreadBox(tuple)
+
+    PThread.run(handle: &handle, args: box)
+  }
+
+  /// Returns `true` if the calling thread is the same as this one.
+  var isCurrent: Bool {
+    return PThread.isCurrentThread(self.handle)
+  }
+
+  /// Returns the current running `Thread`.
+  static var current: Thread {
+    let handle = PThread.currentThread
+    return Thread(handle: handle, desiredName: nil)
+  }
+}
+
+extension Thread: CustomStringConvertible {
+  var description: String {
+    let desiredName = self.desiredName
+    let actualName = self.currentName
+
+    switch (desiredName, actualName) {
+    case (.some(let desiredName), .some(desiredName)):
+      // We know the current, actual name and the desired name and they match. This is hopefully the most common
+      // situation.
+      return "Thread(name = \(desiredName))"
+    case (.some(let desiredName), .some(let actualName)):
+      // We know both names but they're not equal. That's odd but not impossible, some misbehaved library might
+      // have changed the name.
+      return "Thread(desiredName = \(desiredName), actualName = \(actualName))"
+    case (.some(let desiredName), .none):
+      // We only know the desired name and can't get the actual thread name. The OS might not be able to provide
+      // the name to us.
+      return "Thread(desiredName = \(desiredName))"
+    case (.none, .some(let actualName)):
+      // We only know the actual name. This can happen when we don't have a reference to the actually spawned
+      // thread but rather ask for the current thread and then print it.
+      return "Thread(actualName = \(actualName))"
+    case (.none, .none):
+      // We know nothing, sorry.
+      return "Thread(n/a)"
+    }
+  }
+}
+
+extension Thread: Equatable {
+  static func == (lhs: Thread, rhs: Thread) -> Bool {
+    return lhs.withUnsafeThreadHandle { lhs in
+      rhs.withUnsafeThreadHandle { rhs in
+        PThread.compareThreads(lhs, rhs)
+      }
+    }
+  }
+}

--- a/Tests/PThreadExecutorsTests/PThreadTaskExecutorTests.swift
+++ b/Tests/PThreadExecutorsTests/PThreadTaskExecutorTests.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import PThreadExecutors
+
+@Suite
+struct PThreadTaskExecutorTests {
+  @Test
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func runsJobs() async {
+    let executor = PThreadTaskExecutor.make(name: "Test")
+    await withTaskExecutorPreference(executor) {
+      for _ in 0...100 {
+        await Task.yield()
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Motivation

We want to offer an executor that's based on `pthread`s and the platform's native selector system e.g. `epoll` or `kqueue`.

# Modifications

This PR lands the initial infrastructure to support a `pthread` based executor. This requires an internal C library and some abstractions around threads.

# Result

We have a working `pthread` based executor that we can use to build out a thread pool and add additional functionalities to it.