### PR TITLE
Add a `PThreadPoolExecutor`

### DIFF
--- a/Sources/PlatformExecutors/PThreadExecutor/Internal/Thread.swift
+++ b/Sources/PlatformExecutors/PThreadExecutor/Internal/Thread.swift
@@ -14,7 +14,7 @@
 import CPlatformExecutors
 #endif
 
-final class Thread {
+final class Thread: @unchecked Sendable {
   internal typealias ThreadBoxValue = (body: (Thread) -> Void, name: String?)
   internal typealias ThreadBox = Box<ThreadBoxValue>
 
@@ -91,19 +91,19 @@ extension Thread: CustomStringConvertible {
     case (.some(let desiredName), .some(desiredName)):
       // We know the current, actual name and the desired name and they match. This is hopefully the most common
       // situation.
-      return "Thread(name = \(desiredName))"
+      return "Thread(name: \(desiredName))"
     case (.some(let desiredName), .some(let actualName)):
       // We know both names but they're not equal. That's odd but not impossible, some misbehaved library might
       // have changed the name.
-      return "Thread(desiredName = \(desiredName), actualName = \(actualName))"
+      return "Thread(desiredName: \(desiredName), actualName: \(actualName))"
     case (.some(let desiredName), .none):
       // We only know the desired name and can't get the actual thread name. The OS might not be able to provide
       // the name to us.
-      return "Thread(desiredName = \(desiredName))"
+      return "Thread(desiredName: \(desiredName))"
     case (.none, .some(let actualName)):
       // We only know the actual name. This can happen when we don't have a reference to the actually spawned
       // thread but rather ask for the current thread and then print it.
-      return "Thread(actualName = \(actualName))"
+      return "Thread(actualName: \(actualName))"
     case (.none, .none):
       // We know nothing, sorry.
       return "Thread(n/a)"

--- a/Sources/PlatformExecutors/PThreadExecutor/PThreadPoolExecutor.swift
+++ b/Sources/PlatformExecutors/PThreadExecutor/PThreadPoolExecutor.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+internal import Synchronization
+
+/// A task executor that distributes work across multiple `PThreadExecutor` instances.
+///
+/// `PThreadPoolExecutor` provides a multi-threaded execution environment by maintaining a pool of `PThreadExecutor`
+/// instances and distributing jobs across them. This design enables parallel execution while leveraging the
+/// optimized single-threaded executors as building blocks.
+///
+/// ## Usage
+///
+/// ```swift
+/// // Create pool for parallel processing
+/// let pool = PThreadPoolExecutor(name: "ProcessingPool", poolSize: 4)
+///
+/// await withTaskExecutorPreference(pool) {
+///     // Jobs distributed across the pool
+///     async let result1 = heavyComputation1()
+///     async let result2 = heavyComputation2()
+///     async let result3 = heavyComputation3()
+///
+///     return await [result1, result2, result3]
+/// }
+/// ```
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public final class PThreadPoolExecutor: TaskExecutor {
+  /// The pool's executors.
+  private let executors: [PThreadExecutor]
+  /// The current index for selecting the next executor to run on.
+  private let index = Atomic<Int>(0)
+
+  /// Creates a new `PThreadPoolExecutor` with the specified pool size and thread naming.
+  ///
+  /// This initializer creates a pool of `PThreadExecutor` instances, each with its own dedicated thread.
+  ///
+  /// - Parameters:
+  ///   - name: The base name for the executor pool. Each thread in the pool will be named `"<name>-<index>"`
+  ///     where index starts from 0.
+  ///   - poolSize: The number of `PThreadExecutor` instances to create in the pool. Must be greater than 0.
+  public init(
+    name: String,
+    poolSize: Int
+  ) {
+    precondition(poolSize > 0, "The pool size must be positive")
+    var executors = [PThreadExecutor]()
+    executors.reserveCapacity(poolSize)
+    for i in 0..<poolSize {
+      executors.append(PThreadExecutor(name: "\(name)-\(i)"))
+    }
+    self.executors = executors
+  }
+
+  public func enqueue(_ job: UnownedJob) {
+    self.next().enqueue(job)
+  }
+
+  private func next() -> PThreadExecutor {
+    self.executors[abs(self.index.wrappingAdd(1, ordering: .relaxed).newValue % self.executors.count)]
+  }
+}

--- a/Tests/PlatformExecutorsTests/PThreadExecutorTests.swift
+++ b/Tests/PlatformExecutorsTests/PThreadExecutorTests.swift
@@ -14,11 +14,22 @@ import Testing
 import PlatformExecutors
 
 @Suite
-struct PThreadTaskExecutorTests {
+struct PThreadExecutorTests {
   @Test
   @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-  func runsJobs() async {
-    let executor = PThreadTaskExecutor.make(name: "Test")
+  func singleExecutor() async {
+    let executor = PThreadExecutor(name: "Test")
+    await withTaskExecutorPreference(executor) {
+      for _ in 0...100 {
+        await Task.yield()
+      }
+    }
+  }
+
+  @Test
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func poolExecutor() async {
+    let executor = PThreadPoolExecutor(name: "Test", poolSize: 5)
     await withTaskExecutorPreference(executor) {
       for _ in 0...100 {
         await Task.yield()


### PR DESCRIPTION
# Motivation

In a previous PR, I landed support for a simple `PThreadExecutor` which is backed by a single pthread and epoll/kqueue.

# Modification

This PR introduces a new pooled executor of `PThreadExecutor`s which is useful in context where one wants to parallize work across multiple threads.

# Result

We now can create a pool of pthread executors.