### PR TITLE
Add support for job priorities in the PThreadExecutor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,15 +11,11 @@ let package = Package(
       ]
     )
   ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0")
-  ],
   targets: [
     .target(
       name: "PlatformExecutors",
       dependencies: [
-        .product(name: "DequeModule", package: "swift-collections"),
-        .target(name: "CPlatformExecutors"),
+        .target(name: "CPlatformExecutors")
       ]
     ),
     .target(

--- a/Sources/PlatformExecutors/Internal/ExecutorJob+Sequence.swift
+++ b/Sources/PlatformExecutors/Internal/ExecutorJob+Sequence.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension ExecutorJob {
+  var sequenceNumber: UInt64 {
+    get {
+      return unsafe withUnsafeExecutorPrivateData {
+        return unsafe $0.assumingMemoryBound(to: UInt64.self)[0]
+      }
+    }
+    set {
+      return unsafe withUnsafeExecutorPrivateData {
+        unsafe $0.withMemoryRebound(to: UInt64.self) {
+          unsafe $0[0] = newValue
+        }
+      }
+    }
+  }
+}

--- a/Sources/PlatformExecutors/Internal/PriorityQueue.swift
+++ b/Sources/PlatformExecutors/Internal/PriorityQueue.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(WinSDK)
 import Swift
 
 /// A generic priority queue, with a user-defined comparison function.
@@ -39,6 +38,14 @@ struct PriorityQueue<T> {
   ///
   init(compare: @escaping (borrowing T, borrowing T) -> Bool) {
     self.compare = compare
+  }
+
+  var count: Int {
+    self.storage.count
+  }
+
+  var isEmpty: Bool {
+    self.storage.isEmpty
   }
 
   /// Push an item onto the queue.
@@ -198,4 +205,3 @@ extension PriorityQueue where T: Comparable {
     self.init(compare: >)
   }
 }
-#endif

--- a/Sources/PlatformExecutors/Internal/UnownedJob+Compare.swift
+++ b/Sources/PlatformExecutors/Internal/UnownedJob+Compare.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Compare UnownedJobs by priority, breaking ties with the sequence number.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+func compareJobsByPriorityAndSequenceNumber(
+  lhs: UnownedJob,
+  rhs: UnownedJob
+) -> Bool {
+  if lhs.priority == rhs.priority {
+    // If they're the same priority, compare the sequence numbers to
+    // ensure this queue gives stable ordering.  We want the lowest
+    // sequence number first, but note that we want to handle wrapping.
+    let delta = ExecutorJob(lhs).sequenceNumber &- ExecutorJob(rhs).sequenceNumber
+    return (delta >> (UInt.bitWidth - 1)) != 0
+  }
+  return lhs.priority > rhs.priority
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+func compareJobsByPriorityAndID(
+  lhs: UnownedJob,
+  rhs: UnownedJob
+) -> Bool {
+  if lhs.priority == rhs.priority {
+    // If they're the same priority, compare the sequence numbers to
+    // ensure this queue gives stable ordering.  We want the lowest
+    // sequence number first, but note that we want to handle wrapping.
+    let delta = _getJobTaskId(lhs) &- _getJobTaskId(rhs)
+    return (delta >> (UInt.bitWidth - 1)) != 0
+  }
+  return lhs.priority > rhs.priority
+}
+
+/// This is a method from the Concurrency ABI that we are using for fallback job ordering on older deployment
+/// targets
+@_silgen_name("swift_task_getJobTaskId")
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+func _getJobTaskId(_ job: UnownedJob) -> UInt64

--- a/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
+++ b/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
@@ -148,23 +148,6 @@ public protocol Win32EventLoopExecutorDelegate {
 
 }
 
-/// Compare UnownedJobs by priority, breaking ties with the sequence number.
-private func compareJobsByPriority(
-  lhs: UnownedJob,
-  rhs: UnownedJob
-) -> Bool {
-  if lhs.priority == rhs.priority {
-    // If they're the same priority, compare the sequence numbers to
-    // ensure this queue gives stable ordering.  We want the lowest
-    // sequence number first, but note that we want to handle wrapping.
-    let delta =
-      ExecutorJob(lhs).win32Sequence
-      &- ExecutorJob(rhs).win32Sequence
-    return (delta >> (UInt.bitWidth - 1)) != 0
-  }
-  return lhs.priority > rhs.priority
-}
-
 /// Retrieve a message from the Win32 message queue
 ///
 /// This exists to work around the incorrect return type declared by the

--- a/Tests/PlatformExecutorsTests/ExecutorFixture.swift
+++ b/Tests/PlatformExecutorsTests/ExecutorFixture.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(WinSDK)
+#if canImport(WinSDK) || os(Linux)
 import _Concurrency
 import Synchronization
 

--- a/Tests/PlatformExecutorsTests/PThreadExecutorTests.swift
+++ b/Tests/PlatformExecutorsTests/PThreadExecutorTests.swift
@@ -36,4 +36,17 @@ struct PThreadExecutorTests {
       }
     }
   }
+
+  @Test(
+    arguments: [
+      PThreadExecutor(name: "Test") as any Executor,
+      PThreadPoolExecutor(name: "Test", poolSize: 1),
+      PThreadPoolExecutor(name: "Test", poolSize: 5),
+      PThreadMainExecutor(),
+    ]
+  )
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func foo(executor: any Executor) async throws {
+    #expect(await ExecutorFixture.test(executor: executor))
+  }
 }


### PR DESCRIPTION
# Motivation

We want to support priorities in our executor so that they handle different task priorities correctly.

# Modifications

This PR adds support for priorities to the PThreadExecutor by using the existing PriorityQueue. It also allows us to drop the dependency on swift-collections. Lastly, this PR enables running the PThread executors through the existing executor test fixtures.

# Result

We properly support priorities now.