### PR TITLE
Improve performance of executors and add `PlatformExecutorFactory`.

### DIFF
--- a/Examples/PlatformExecutors/PlatformExecutorsExample.swift
+++ b/Examples/PlatformExecutors/PlatformExecutorsExample.swift
@@ -23,8 +23,11 @@ struct Example {
 
     await self.run(executor: nil)
     await self.runGroup(executor: nil)
+
+    #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
     await self.run(executor: PThreadExecutor(name: "Executor"))
     await self.runGroup(executor: PThreadPoolExecutor(name: "Pool", poolSize: 8))
+    #endif
   }
 
   @concurrent

--- a/Examples/PlatformExecutors/PlatformExecutorsExample.swift
+++ b/Examples/PlatformExecutors/PlatformExecutorsExample.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import PlatformExecutors
+import Dispatch
+
+@available(macOS 26, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+typealias DefaultExecutorFactory = PlatformExecutorFactory
+
+@main
+@available(macOS 26, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+struct Example {
+  static func main() async throws {
+
+    await self.run(executor: nil)
+    await self.runGroup(executor: nil)
+    await self.run(executor: PThreadExecutor(name: "Executor"))
+    await self.runGroup(executor: PThreadPoolExecutor(name: "Pool", poolSize: 8))
+  }
+
+  @concurrent
+  static func run(
+    executor: TaskExecutor?,
+    iterations: Int = 10_000_000
+  ) async {
+    let duration = await ContinuousClock().measure {
+      await withTaskExecutorPreference(executor) {
+        for _ in 0..<iterations {
+          await withUnsafeContinuation { cont in
+            cont.resume()
+          }
+        }
+      }
+    }
+
+    print("Executor \(String(describing: executor)) took \(duration) seconds for \(iterations) iterations")
+  }
+
+  @concurrent
+  static func runGroup(
+    executor: TaskExecutor?,
+    childTasks: Int = 10,
+    iterations: Int = 10_000_000
+  ) async {
+    let duration = await ContinuousClock().measure {
+      await withTaskExecutorPreference(executor) {
+        await withTaskGroup { group in
+          for _ in 0..<childTasks {
+            group.addTask {
+              for _ in 0..<iterations {
+                await withUnsafeContinuation { cont in
+                  cont.resume()
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    print(
+      "Executor \(String(describing: executor)) took \(duration) seconds for \(iterations) iterations with \(childTasks) child tasks"
+    )
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,22 @@ let package = Package(
         .define("_GNU_SOURCE")
       ]
     ),
+
+    // Tests
     .testTarget(
       name: "PlatformExecutorsTests",
       dependencies: [
-        "PlatformExecutors"
+        .target(name: "PlatformExecutors")
       ]
+    ),
+
+    // Examples
+    .executableTarget(
+      name: "PlatformExecutorsExample",
+      dependencies: [
+        .target(name: "PlatformExecutors")
+      ],
+      path: "Examples/PlatformExecutors"
     ),
   ]
 )

--- a/Sources/PlatformExecutors/PThread/Internal/Selector/syscall.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/Selector/syscall.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
@@ -138,3 +139,4 @@ private func isUnacceptableErrno(_ code: Int32) -> Bool {
   }
   #endif
 }
+#endif

--- a/Sources/PlatformExecutors/PThread/Internal/Thread.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/Thread.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
 #if os(Linux) || os(FreeBSD) || os(Android)
 import CPlatformExecutors
 #endif
@@ -120,3 +121,4 @@ extension Thread: Equatable {
     }
   }
 }
+#endif

--- a/Sources/PlatformExecutors/PThread/PThreadExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadExecutor.swift
@@ -25,14 +25,6 @@ import Dispatch
 /// ## Usage
 ///
 /// ```swift
-/// // Create executor for actor isolation
-/// actor DatabaseActor {
-///     nonisolated let executor = PThreadExecutor(name: "DatabaseActor")
-///     nonisolated var unownedExecutor: UnownedSerialExecutor {
-///         executor.asUnownedSerialExecutor()
-///     }
-/// }
-///
 /// // Use with task executor preference
 /// let executor = PThreadExecutor(name: "ProcessingThread")
 /// await withTaskExecutorPreference(executor) {
@@ -133,6 +125,13 @@ public final class PThreadExecutor: TaskExecutor, @unchecked Sendable {
   /// - Parameter name: The name assigned to the executor's background thread. This name appears in debugging
   ///   tools and crash reports for easier identification.
   public convenience init(name: String) {
+    self.init(name: name, poolExecutor: nil)
+  }
+
+  internal convenience init(
+    name: String,
+    poolExecutor: PThreadPoolExecutor?
+  ) {
     self.init()
 
     let conditionVariable = ConditionVariable(false)
@@ -140,8 +139,24 @@ public final class PThreadExecutor: TaskExecutor, @unchecked Sendable {
       assert(Thread.current == thread)
       do {
         conditionVariable.signal { $0.toggle() }
-        try self.run { job in
-          job.runSynchronously(on: self.asUnownedTaskExecutor())
+
+        // It is incredibly important that we pass the right task executor
+        // to the run methods otherwise the Concurrency runtime will re-enqueue
+        // the task over and over again. If this executor is part of a thread pool
+        // then we must pass the pool as the executor.
+        if let poolExecutor {
+          // We are creating the unowned task executor outside the closure to
+          // avoid retaining the pool and creating a reference cycle. Since, the
+          // pool is holding all the executors it is guaranteed that the pool
+          // is alive long enough.
+          let poolExecutor = poolExecutor.asUnownedTaskExecutor()
+          try self.run { job in
+            job.runSynchronously(on: poolExecutor)
+          }
+        } else {
+          try self.run { job in
+            job.runSynchronously(on: self.asUnownedTaskExecutor())
+          }
         }
       } catch {
         // We fatalError here because the only reasons this can be hit is if the underlying kqueue/epoll give us

--- a/Sources/PlatformExecutors/PThread/PThreadExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadExecutor.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
 internal import Synchronization
 
 #if canImport(Darwin)
@@ -336,3 +337,4 @@ private struct NonCopyablePriorityQueue: ~Copyable {
     self.queue.push(newElement)
   }
 }
+#endif

--- a/Sources/PlatformExecutors/PThread/PThreadMainExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadMainExecutor.swift
@@ -25,7 +25,7 @@
 /// mainExecutor.stop()
 /// ```
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public final class PThreadMainExecutor: MainExecutor, TaskExecutor, @unchecked Sendable {
+public final class PThreadMainExecutor: MainExecutor, @unchecked Sendable {
   private let pThreadExecutor: PThreadExecutor
 
   /// Creates a new `PThreadMainExecutor` that takes control of the current thread.
@@ -40,11 +40,7 @@ public final class PThreadMainExecutor: MainExecutor, TaskExecutor, @unchecked S
   public func run() throws {
     // We are taking over the current thread
     try self.pThreadExecutor.run { job in
-      job
-        .runSynchronously(
-          isolatedTo: self.asUnownedSerialExecutor(),
-          taskExecutor: self.asUnownedTaskExecutor()
-        )
+      job.runSynchronously(on: self.asUnownedSerialExecutor())
     }
   }
 

--- a/Sources/PlatformExecutors/PThread/PThreadMainExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadMainExecutor.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
 /// A main executor that provides serial execution by taking over the current thread.
 ///
 /// ## Usage
@@ -55,3 +56,4 @@ extension PThreadMainExecutor: CustomStringConvertible {
     "PThreadMainExecutor(\(self.pThreadExecutor.thread?.description ?? "not running"))"
   }
 }
+#endif

--- a/Sources/PlatformExecutors/PThread/PThreadPoolExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadPoolExecutor.swift
@@ -35,8 +35,13 @@ internal import Synchronization
 /// ```
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public final class PThreadPoolExecutor: TaskExecutor {
+  /// The pool's name.
+  private let name: String
   /// The pool's executors.
-  private let executors: [PThreadExecutor]
+  ///
+  /// This is nonisolated(unsafe) and a var since we need to pass self to the individual threads which requires
+  /// us to be fully initialized.
+  private nonisolated(unsafe) var executors: [PThreadExecutor]!
   /// The current index for selecting the next executor to run on.
   private let index = Atomic<Int>(0)
 
@@ -52,20 +57,28 @@ public final class PThreadPoolExecutor: TaskExecutor {
     name: String,
     poolSize: Int
   ) {
+    self.name = name
     precondition(poolSize > 0, "The pool size must be positive")
     var executors = [PThreadExecutor]()
     executors.reserveCapacity(poolSize)
     for i in 0..<poolSize {
-      executors.append(PThreadExecutor(name: "\(name)-\(i)"))
+      executors.append(PThreadExecutor(name: "\(name)-\(i)", poolExecutor: self))
     }
     self.executors = executors
   }
 
-  public func enqueue(_ job: UnownedJob) {
+  public func enqueue(_ job: consuming ExecutorJob) {
     self.next().enqueue(job)
   }
 
   private func next() -> PThreadExecutor {
     self.executors[abs(self.index.wrappingAdd(1, ordering: .relaxed).newValue % self.executors.count)]
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension PThreadPoolExecutor: CustomStringConvertible {
+  public var description: String {
+    "PThreadPoolExecutor(\(self.name))"
   }
 }

--- a/Sources/PlatformExecutors/PThread/PThreadPoolExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadPoolExecutor.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
 internal import Synchronization
 
 /// A task executor that distributes work across multiple `PThreadExecutor` instances.
@@ -82,3 +83,4 @@ extension PThreadPoolExecutor: CustomStringConvertible {
     "PThreadPoolExecutor(\(self.name))"
   }
 }
+#endif

--- a/Sources/PlatformExecutors/PlatformExecutorFactory.swift
+++ b/Sources/PlatformExecutors/PlatformExecutorFactory.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+/// Provides a reasonable default executor factory for your platform.
+public struct PlatformExecutorFactory: ExecutorFactory {
+  public static let mainExecutor: any MainExecutor = Win32EventLoopExecutor(isMainExecutor: true)
+  public static let defaultExecutor: any TaskExecutor = Win32ThreadPoolExecutor()
+}
+#elseif os(Linux) || os(FreeBSD) || canImport(Darwin)
+/// Provides a reasonable default executor factory for your platform.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+public struct PlatformExecutorFactory: ExecutorFactory {
+  public static let mainExecutor: any MainExecutor = PThreadMainExecutor()
+  public static let defaultExecutor: any TaskExecutor = PThreadPoolExecutor(name: "global", poolSize: 8)
+}
+#else
+#error("Unsupported platform")
+#endif

--- a/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
+++ b/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
@@ -738,4 +738,18 @@ extension Win32ThreadPoolExecutor: SchedulableExecutor {
   }
 
 }
+
+private func compareJobsByPriority(
+  lhs: UnownedJob,
+  rhs: UnownedJob
+) -> Bool {
+  if lhs.priority == rhs.priority {
+    // If they're the same priority, compare the sequence numbers to
+    // ensure this queue gives stable ordering.  We want the lowest
+    // sequence number first, but note that we want to handle wrapping.
+    let delta = ExecutorJob(lhs).win32Sequence &- ExecutorJob(rhs).win32Sequence
+    return (delta >> (UInt.bitWidth - 1)) != 0
+  }
+  return lhs.priority > rhs.priority
+}
 #endif

--- a/Tests/PlatformExecutorsTests/PThreadExecutorTests.swift
+++ b/Tests/PlatformExecutorsTests/PThreadExecutorTests.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if os(Linux) || os(FreeBSD) || canImport(Darwin)
+
 import Testing
 import PlatformExecutors
 
@@ -50,3 +52,4 @@ struct PThreadExecutorTests {
     #expect(await ExecutorFixture.test(executor: executor))
   }
 }
+#endif


### PR DESCRIPTION
# Motivation

We want our new executors to be as fast as the current ones. This means we need to ensure that there are no unnecessary re-enqueues or context switches.

# Modifications

This PR drops any conformance to `Serial` or `Task` executor on types that already have the other. This is due to a performance foot-gun in the runtime which means no type should conform to both at once. This PR also provides the `PlatfromExecutorFactory`.

Lastly, this PR also adds an example target showing how to use some of the new executors.

# Result
We now can use our new executors as defaults and they have matching performance with the current ones