### PR TITLE
Appropriately size the default executor on Linux

### DIFF
--- a/Examples/PlatformExecutors/PlatformExecutorsExample.swift
+++ b/Examples/PlatformExecutors/PlatformExecutorsExample.swift
@@ -26,7 +26,7 @@ struct Example {
 
     #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
     await self.run(executor: PThreadExecutor(name: "Executor"))
-    await self.runGroup(executor: PThreadPoolExecutor(name: "Pool", poolSize: 8))
+    await self.runGroup(executor: PThreadPoolExecutor(name: "Pool"))
     #endif
   }
 

--- a/Sources/PlatformExecutors/PThread/Internal/SystemCoreCount.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/SystemCoreCount.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux) || os(FreeBSD) || canImport(Darwin)
+
+#if canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+enum SystemCoreCount {
+  static var coreCount: Int {
+    #if os(Linux)
+    if let quota2 = self.coreCountCgroup2Restriction() {
+      return quota2
+    } else if let quota = self.coreCountCgroup1Restriction() {
+      return quota
+    } else if let cpusetCount = self.coreCount(cpuset: self.cpuSetPath) {
+      return cpusetCount
+    } else {
+      return sysconf(CInt(_SC_NPROCESSORS_ONLN))
+    }
+    #else
+    return sysconf(CInt(_SC_NPROCESSORS_ONLN))
+    #endif
+  }
+
+  #if os(Linux)
+  static let cfsQuotaPath = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+  static let cfsPeriodPath = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+  static let cpuSetPath = "/sys/fs/cgroup/cpuset/cpuset.cpus"
+  static let cfsCpuMaxPath = "/sys/fs/cgroup/cpu.max"
+
+  static func coreCount(cpuset cpusetPath: String) -> Int? {
+    guard
+      let cpuset = try? firstLineOfFile(path: cpusetPath).split(separator: ","),
+      !cpuset.isEmpty
+    else { return nil }
+    return cpuset.map(countCoreIds).reduce(0, +)
+  }
+
+  private static func countCoreIds(cores: Substring) -> Int {
+    let ids = cores.split(separator: "-", maxSplits: 1)
+    guard
+      let first = ids.first.flatMap({ Int($0, radix: 10) }),
+      let last = ids.last.flatMap({ Int($0, radix: 10) }),
+      last >= first
+    else { preconditionFailure("cpuset format is incorrect") }
+    return 1 + last - first
+  }
+
+  /// Get the available core count according to cgroup1 restrictions.
+  /// Round up to the next whole number.
+  static func coreCountCgroup1Restriction(
+    quota quotaPath: String = cfsQuotaPath,
+    period periodPath: String = cfsPeriodPath
+  ) -> Int? {
+    guard
+      let quota = try? Int(firstLineOfFile(path: quotaPath)),
+      quota > 0
+    else { return nil }
+    guard
+      let period = try? Int(firstLineOfFile(path: periodPath)),
+      period > 0
+    else { return nil }
+    return (quota - 1 + period) / period  // always round up if fractional CPU quota requested
+  }
+
+  /// Get the available core count according to cgroup2 restrictions.
+  /// Round up to the next whole number.
+  static func coreCountCgroup2Restriction(cpuMaxPath: String = cfsCpuMaxPath) -> Int? {
+    guard let maxDetails = try? firstLineOfFile(path: cpuMaxPath),
+      let spaceIndex = maxDetails.firstIndex(of: " "),
+      let quota = Int(maxDetails[maxDetails.startIndex..<spaceIndex]),
+      let period = Int(maxDetails[maxDetails.index(after: spaceIndex)..<maxDetails.endIndex])
+    else { return nil }
+    return (quota - 1 + period) / period  // always round up if fractional CPU quota requested
+  }
+
+  private static func firstLineOfFile(path: String) throws -> String {
+    return try String(contentsOfFile: path, encoding: .utf8)
+  }
+
+  #endif
+}
+
+#endif

--- a/Sources/PlatformExecutors/PThread/PThreadExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadExecutor.swift
@@ -54,9 +54,6 @@ public final class PThreadExecutor: TaskExecutor, @unchecked Sendable {
   /// This is the state that is bound to this thread.
   struct ThreadBoundState: ~Copyable {
     /// The executor's thread.
-    ///
-    /// This is an implicit unwrap since we need to create the executor before the thread. We are ensuring
-    /// it is actually set before anything happens
     fileprivate var thread: Thread?
 
     /// The executor's selector.
@@ -84,8 +81,7 @@ public final class PThreadExecutor: TaskExecutor, @unchecked Sendable {
 
     /// The backing storage for the selector.
     ///
-    /// This is an implicit unwrap since we need to create the executor before the selector. We are ensuring
-    /// it is actually set before anything happens
+    /// This is a force try since there really is no way to handle these errors and this should never fail.
     let _selector = try! Selector()
 
     /// The backing storage of the next executed jobs.

--- a/Sources/PlatformExecutors/PThread/PThreadPoolExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadPoolExecutor.swift
@@ -54,11 +54,13 @@ public final class PThreadPoolExecutor: TaskExecutor {
   ///   - name: The base name for the executor pool. Each thread in the pool will be named `"<name>-<index>"`
   ///     where index starts from 0.
   ///   - poolSize: The number of `PThreadExecutor` instances to create in the pool. Must be greater than 0.
+  ///   If `nil` is passed then the systems available core count will be used. Defaults to `nil`.
   public init(
     name: String,
-    poolSize: Int
+    poolSize: Int? = nil
   ) {
-    self.name = name
+    let poolSize = poolSize ?? SystemCoreCount.coreCount
+    self.name = "\(name)-size(\(poolSize))"
     precondition(poolSize > 0, "The pool size must be positive")
     var executors = [PThreadExecutor]()
     executors.reserveCapacity(poolSize)

--- a/Sources/PlatformExecutors/PlatformExecutorFactory.swift
+++ b/Sources/PlatformExecutors/PlatformExecutorFactory.swift
@@ -17,11 +17,29 @@ public struct PlatformExecutorFactory: ExecutorFactory {
   public static let defaultExecutor: any TaskExecutor = Win32ThreadPoolExecutor()
 }
 #elseif os(Linux) || os(FreeBSD) || canImport(Darwin)
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 /// Provides a reasonable default executor factory for your platform.
+///
+/// By default the size of the ``defaultExecutor`` is determined by the systems available core count.
+/// On Linux this takes into account C1 and C2 group restrictions. Additionally, the size can be customized
+/// by setting the `SWIFT_PLATFORM_DEFAULT_EXECUTOR_POOL_SIZE` environment variable.
 @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = PThreadMainExecutor()
-  public static let defaultExecutor: any TaskExecutor = PThreadPoolExecutor(name: "global", poolSize: 8)
+  public static let defaultExecutor: any TaskExecutor = {
+    let coreCountEnvironment = ProcessInfo.processInfo
+      .environment["SWIFT_PLATFORM_DEFAULT_EXECUTOR_POOL_SIZE"]
+    let coreCount = coreCountEnvironment.flatMap { Int($0) } ?? SystemCoreCount.coreCount
+    return PThreadPoolExecutor(
+      name: "global",
+      poolSize: coreCount
+    )
+  }()
 }
 #else
 #error("Unsupported platform")


### PR DESCRIPTION
# Motivation

The default executor on Linux should be appropriately sized to the available cores of the system.

# Modifications

This PR configures the default Linux executor to use the available cores of the system accounting for C1 and C2 group restrictions. Additionally, it also allows to override the size by checking for an environment variable.

# Result

Appropriate thread pool sizes on Linux while providing the user customization options.