### PR TITLE
Provide methods to create task, task pool and serial executor

### DIFF
--- a/Sources/PlatformExecutors/PThread/Internal/AsyncDo.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/AsyncDo.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Structured resource management helper that ensures cleanup code runs in all execution paths.
+///
+/// This function guarantees that the finally block will execute even if the body throws an error
+/// or the task is cancelled. The finally block runs in an uncancellable task to prevent resource leaks.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+nonisolated(nonsending) func asyncDo<Return, Failure: Error>(
+  body: () async throws(Failure) -> Return,
+  finally: sending @escaping () async -> Void
+) async throws(Failure) -> Return {
+  let result: Return
+  do {
+    result = try await body()
+  } catch {
+    await Task {
+      await finally()
+    }.value
+    throw error
+  }
+
+  await Task {
+    await finally()
+  }.value
+  return result
+}

--- a/Sources/PlatformExecutors/PThread/Internal/PThread.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/PThread.swift
@@ -125,7 +125,7 @@ enum PThread {
           }
         }
 
-        body(Thread(handle: hThread, desiredName: name))
+        body()
 
         #if os(Android)
         return UnsafeMutableRawPointer(bitPattern: 0xdeadbee)!
@@ -148,6 +148,11 @@ enum PThread {
 
   static func compareThreads(_ lhs: PThread.ThreadHandle, _ rhs: PThread.ThreadHandle) -> Bool {
     return pthread_equal(lhs, rhs) != 0
+  }
+
+  static func joinThread(_ thread: PThread.ThreadHandle) {
+    let result = pthread_join(thread, nil)
+    precondition(result == 0, "pthread_join failed with error code: \(result)")
   }
 }
 

--- a/Sources/PlatformExecutors/PThread/PThreadMainExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadMainExecutor.swift
@@ -26,34 +26,34 @@
 /// mainExecutor.stop()
 /// ```
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public final class PThreadMainExecutor: MainExecutor, @unchecked Sendable {
-  private let pThreadExecutor: PThreadExecutor
+package final class PThreadMainExecutor: MainExecutor, @unchecked Sendable {
+  private let pThreadExecutor: PThreadExecutor!
 
   /// Creates a new `PThreadMainExecutor` that takes control of the current thread.
-  public init() {
+  package init() {
     self.pThreadExecutor = PThreadExecutor()
   }
 
-  public func enqueue(_ job: UnownedJob) {
+  package func enqueue(_ job: UnownedJob) {
     self.pThreadExecutor.enqueue(job)
   }
 
-  public func run() throws {
+  package func run() throws {
     // We are taking over the current thread
     try self.pThreadExecutor.run { job in
       job.runSynchronously(on: self.asUnownedSerialExecutor())
     }
   }
 
-  public func stop() {
+  package func stop() {
     self.pThreadExecutor.stop()
   }
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PThreadMainExecutor: CustomStringConvertible {
-  public var description: String {
-    "PThreadMainExecutor(\(self.pThreadExecutor.thread?.description ?? "not running"))"
+  package var description: String {
+    "PThreadMainExecutor(\(self.pThreadExecutor.threadDescription))"
   }
 }
 #endif

--- a/Sources/PlatformExecutors/PThread/PThreadSerialExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadSerialExecutor.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+/// A serial executor that provides serial execution by spawning a new thread.
+///
+/// ## Usage
+///
+/// ```swift
+/// // Create main executor on current thread
+/// let mainExecutor = PThreadMainExecutor()
+///
+/// // Run the executor loop
+/// try mainExecutor.run()
+///
+/// // Stop the executor from another context
+/// mainExecutor.stop()
+/// ```
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public final class PThreadSerialExecutor: SerialExecutor, @unchecked Sendable {
+  /// This is implicity unwrapped since we need to pass self as the serial executor.
+  private var pThreadExecutor: PThreadExecutor!
+
+  /// Default initializer for internal use.
+  internal init() {
+    // pThreadExecutor will be set by the caller
+  }
+
+  /// Creates a new `PThreadSerialExecutor` with a named background thread.
+  ///
+  /// This initializer creates a new executor with a dedicated background thread. The executor immediately
+  /// begins processing jobs after initialization completes. The background thread continues running until
+  /// the executor is deallocated.
+  ///
+  /// - Parameter name: The name assigned to the executor's background thread. This name appears in debugging
+  ///   tools and crash reports for easier identification.
+  public init(name: String) {
+    self.pThreadExecutor = PThreadExecutor(
+      name: name,
+      serialExecutor: self.asUnownedSerialExecutor(),
+      taskExecutor: nil
+    )
+  }
+
+  /// Creates a new platform-native serial executor.
+  ///
+  /// This method creates a serial executor backed by a dedicated pthread and ensures proper
+  /// thread lifecycle management. The executor's thread will be automatically stopped and
+  /// joined when the body closure completes, ensuring no thread leaks.
+  ///
+  /// - Parameters:
+  ///   - name: The name assigned to the executor's background thread.
+  ///   - body: A closure that gets access to the serial executor for the duration of execution.
+  /// - Returns: The value returned by the body closure.
+  public nonisolated(nonsending) static func withExecutor<Return, Failure: Error>(
+    name: String,
+    body: (PThreadSerialExecutor) async throws(Failure) -> Return
+  ) async throws(Failure) -> Return {
+    do {
+      return try await self._withExecutor(
+        name: name,
+        serialExecutor: nil,
+        body: body
+      )
+    } catch {
+      throw error as! Failure
+    }
+  }
+
+  // For some reason using typed throws here trips over the compiler
+  // and it is not able to reason that the thrown error inside asyncDo is a Failure
+  internal nonisolated(nonsending) static func _withExecutor<Return>(
+    name: String,
+    serialExecutor: UnownedSerialExecutor?,
+    body: (PThreadSerialExecutor) async throws -> Return
+  ) async rethrows -> Return {
+    let executor = PThreadSerialExecutor()
+    executor.pThreadExecutor = PThreadExecutor(
+      name: name,
+      serialExecutor: serialExecutor ?? executor.asUnownedSerialExecutor(),
+      taskExecutor: nil
+    )
+
+    return try await asyncDo {
+      try await body(executor)
+    } finally: {
+      executor.pThreadExecutor.shutdown()
+    }
+  }
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    self.pThreadExecutor.enqueue(job)
+  }
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+extension PThreadSerialExecutor: CustomStringConvertible {
+  public var description: String {
+    "PThreadSerialExecutor(\(self.pThreadExecutor.threadDescription))"
+  }
+}
+#endif

--- a/Sources/PlatformExecutors/PlatformSerialExecutor.swift
+++ b/Sources/PlatformExecutors/PlatformSerialExecutor.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A platform-native task executor.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public final class PlatformSerialExecutor: SerialExecutor {
+  #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+  typealias Executor = PThreadSerialExecutor
+  #elseif os(Windows)
+  // TODO: This is not the right type
+  typealias Executor = Win32EventLoopExecutor
+  #endif
+
+  // This is implicitly unwrapped and nonisolated(unsafe) since we need create
+  // the platform executor first to pass itself as the unowned task executor.
+  internal nonisolated(unsafe) var executor: Executor!
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    self.executor.enqueue(job)
+  }
+}

--- a/Sources/PlatformExecutors/PlatformTaskExecutor.swift
+++ b/Sources/PlatformExecutors/PlatformTaskExecutor.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A platform-native task executor.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public final class PlatformTaskExecutor: TaskExecutor {
+  #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+  typealias Executor = PThreadExecutor
+  #elseif os(Windows)
+  // TODO: This is not the right type
+  typealias Executor = Win32EventLoopExecutor
+  #endif
+
+  // This is implicitly unwrapped and nonisolated(unsafe) since we need create
+  // the platform executor first to pass itself as the unowned task executor.
+  internal nonisolated(unsafe) var executor: Executor!
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    self.executor.enqueue(job)
+  }
+}

--- a/Sources/PlatformExecutors/PlatformTaskPoolExecutor.swift
+++ b/Sources/PlatformExecutors/PlatformTaskPoolExecutor.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A platform-native that distributes work across multiple threads.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+public final class PlatformTaskPoolExecutor: TaskExecutor {
+  #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+  typealias Executor = PThreadPoolExecutor
+  #elseif os(Windows)
+  typealias Executor = Win32ThreadPoolExecutor
+  #endif
+
+  // This is implicitly unwrapped and nonisolated(unsafe) since we need create
+  // the platform executor first to pass itself as the unowned task executor.
+  internal nonisolated(unsafe) var executor: Executor!
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    self.executor.enqueue(job)
+  }
+}

--- a/Tests/PlatformExecutorsTests/PlatformExecutorTests.swift
+++ b/Tests/PlatformExecutorsTests/PlatformExecutorTests.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Linux) || os(FreeBSD) || canImport(Darwin)
+
+import Testing
+import PlatformExecutors
+
+@Suite
+struct PlatformExecutorTests {
+  @Test()
+  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+  func test() async throws {
+    await PlatformExecutorFactory.withTaskExecutor(name: "Test") { executor in
+      #expect(await ExecutorFixture.test(executor: executor))
+    }
+    await PlatformExecutorFactory.withTaskPoolExecutor(name: "Test") { executor in
+      #expect(await ExecutorFixture.test(executor: executor))
+    }
+    await PlatformExecutorFactory.withSerialExecutor(name: "Test") { executor in
+      #expect(await ExecutorFixture.test(executor: executor))
+    }
+  }
+}
+#endif


### PR DESCRIPTION
# Motivation

Outside of the default executors users might want to create their own custom task, task pool or serial executor e.g. to back an actor or move work into its own separate executor.

# Modifications

This PR introduces a new `PThreadSerialExecutor` and provides new factory methods on the `PlatformExecutorFactory` to create specific kinds of executors.

# Results

Users now have an easy to use API to create platform-native specific executors.