### PR TITLE
Darwin executor

### DIFF
--- a/Sources/CPlatformExecutors/include/CPlatformExecutors.h
+++ b/Sources/CPlatformExecutors/include/CPlatformExecutors.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef C_PTHREAD_EXECUTORS_LINUX_H
-#define C_PTHREAD_EXECUTORS_LINUX_H
+#ifndef C_PLATFORM_EXECUTORS_H
+#define C_PLATFORM_EXECUTORS_H
 
 #ifdef __linux__
 #include <sys/epoll.h>
@@ -23,4 +23,17 @@ int CPlatformExecutors_pthread_setname_np(pthread_t thread, const char *name);
 int CPlatformExecutors_pthread_getname_np(pthread_t thread, char *name, size_t len);
 
 #endif
+
+#include <dlfcn.h>
+
+#ifdef __APPLE__
+
+// Export RTLD_NEXT constant for Swift
+static void* const CPlatformExecutors_RTLD_NEXT = RTLD_NEXT;
+
+// Only essential functions that cannot be implemented in Swift
+void CPlatformExecutors_dispatchMain(void) __attribute__((noreturn));
+
 #endif
+
+#endif // C_PLATFORM_EXECUTORS_H

--- a/Sources/CPlatformExecutors/shim.c
+++ b/Sources/CPlatformExecutors/shim.c
@@ -51,4 +51,16 @@ int CPlatformExecutors_pthread_getname_np(pthread_t thread, char *name, size_t l
     return pthread_getname_np(thread, name, len);
 #endif
 }
+
 #endif
+
+// Dispatch executor support (Darwin only)
+#ifdef __APPLE__
+
+#include <dispatch/dispatch.h>
+
+void CPlatformExecutors_dispatchMain(void) {
+    dispatch_main();
+}
+
+#endif // __has_include(<dispatch/dispatch.h>)

--- a/Sources/PlatformExecutors/Dispatch/DispatchGlobalExecutor.swift
+++ b/Sources/PlatformExecutors/Dispatch/DispatchGlobalExecutor.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+package final class DispatchGlobalTaskExecutor: TaskExecutor, @unchecked Sendable {
+  package init() {}
+
+  package func enqueue(_ job: consuming ExecutorJob) {
+    _dispatchEnqueueGlobal(
+      _Concurrency.UnownedJob(job),
+      taskExecutor: self.asUnownedTaskExecutor()
+    )
+  }
+}
+
+#endif

--- a/Sources/PlatformExecutors/Dispatch/DispatchMainExecutor.swift
+++ b/Sources/PlatformExecutors/Dispatch/DispatchMainExecutor.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+package class DispatchMainExecutor: MainExecutor, @unchecked Sendable {
+  var threaded = false
+
+  package init() {}
+
+  package func run() throws {
+    if self.threaded {
+      fatalError("DispatchMainExecutor does not support recursion")
+    }
+
+    self.threaded = true
+    _dispatchMain()
+  }
+
+  package func stop() {
+    fatalError("DispatchMainExecutor cannot be stopped")
+  }
+
+  package func enqueue(_ job: consuming ExecutorJob) {
+    _dispatchEnqueueMain(
+      _Concurrency.UnownedJob(job),
+      serialExecutor: self.asUnownedSerialExecutor()
+    )
+  }
+
+  package func checkIsolated() {
+    _dispatchAssertMainQueue()
+  }
+}
+
+#endif

--- a/Sources/PlatformExecutors/Dispatch/DispatchSerialExecutor.swift
+++ b/Sources/PlatformExecutors/Dispatch/DispatchSerialExecutor.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Dispatch
+
+/// This wrapper primarly exists since we need to call the `runSynchronously`
+/// with the ``PlatformSerialExecutor`` for the tracking to work correctly.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+package final class DispatchSerialExecutor: SerialExecutor, @unchecked Sendable {
+  private let queue: DispatchQueue
+  private let serialExecutor: UnownedSerialExecutor
+
+  package init(name: String, serialExecutor: UnownedSerialExecutor) {
+    self.queue = DispatchQueue(label: name)
+    self.serialExecutor = serialExecutor
+  }
+
+  package func enqueue(_ job: consuming ExecutorJob) {
+    let job = UnownedJob(job)
+    self.queue.async {
+      job.runSynchronously(on: self.serialExecutor)
+    }
+  }
+}
+
+#endif

--- a/Sources/PlatformExecutors/Dispatch/DispatchTaskExecutor.swift
+++ b/Sources/PlatformExecutors/Dispatch/DispatchTaskExecutor.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Dispatch
+
+/// This wrapper primarly exists since we need to call the `runSynchronously`
+/// with the ``PlatformTaskExecutor`` for the tracking to work correctly.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+package final class DispatchTaskExecutor: TaskExecutor, @unchecked Sendable {
+  private let queue: DispatchQueue
+  private let taskExecutor: UnownedTaskExecutor
+
+  package init(name: String, taskExecutor: UnownedTaskExecutor) {
+    self.queue = DispatchQueue(label: name)
+    self.taskExecutor = taskExecutor
+  }
+
+  package func enqueue(_ job: consuming ExecutorJob) {
+    let job = UnownedJob(job)
+    self.queue.async {
+      job.runSynchronously(on: self.taskExecutor)
+    }
+  }
+}
+
+#endif

--- a/Sources/PlatformExecutors/Dispatch/DispatchTaskPoolExecutor.swift
+++ b/Sources/PlatformExecutors/Dispatch/DispatchTaskPoolExecutor.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Dispatch
+
+/// This wrapper primarly exists since we need to call the `runSynchronously`
+/// with the ``PlatformTaskExecutor`` for the tracking to work correctly.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+package final class DispatchTaskPoolExecutor: TaskExecutor, @unchecked Sendable {
+  private let queue: DispatchQueue
+  private let taskExecutor: UnownedTaskExecutor
+
+  package init(name: String, taskExecutor: UnownedTaskExecutor) {
+    // There is no way to set the pool width of a dispatch queue
+    self.queue = DispatchQueue(label: name, attributes: .concurrent)
+    self.taskExecutor = taskExecutor
+  }
+
+  package func enqueue(_ job: consuming ExecutorJob) {
+    let job = UnownedJob(job)
+    self.queue.async {
+      job.runSynchronously(on: self.taskExecutor)
+    }
+  }
+}
+
+#endif

--- a/Sources/PlatformExecutors/Dispatch/Internal/DispatchRuntimeMethods.swift
+++ b/Sources/PlatformExecutors/Dispatch/Internal/DispatchRuntimeMethods.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import CPlatformExecutors
+import Dispatch
+
+// Thread-safe initialization of the dispatch function pointer
+private let dispatchAsyncSwiftJobFunc: (@convention(c) (DispatchQueue, UnsafeMutableRawPointer, UInt32) -> Void)? = {
+  guard let symbol = dlsym(CPlatformExecutors_RTLD_NEXT, "dispatch_async_swift_job") else {
+    return nil
+  }
+  return unsafeBitCast(symbol, to: (@convention(c) (DispatchQueue, UnsafeMutableRawPointer, UInt32) -> Void).self)
+}()
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+private let _enqueueJobOnTaskExecutor: @Sendable (DispatchQueue, UnownedJob, UnownedTaskExecutor) -> Void = {
+  guard let dispatchAsyncSwiftJobFunc else {
+    // We can't find the `dispatch_async_swift_job` method so let's fallback
+    return { queue, job, taskExecutor in
+      queue.async {
+        job.runSynchronously(on: taskExecutor)
+      }
+    }
+  }
+  return { queue, job, _ in
+    // Convert UnownedJob to a raw pointer for C interface
+    // Dispatch is storing this pointer after the call to enqueue as well so we
+    // cannot use a scoped with-style method here
+    let jobPointer = unsafeBitCast(job, to: UnsafeMutableRawPointer.self)
+    dispatchAsyncSwiftJobFunc(
+      queue,
+      jobPointer,
+      qosClassForPriority(job.priority).rawValue.rawValue
+    )
+  }
+}()
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+private let _enqueueJobOnSerialExecutor: @Sendable (DispatchQueue, UnownedJob, UnownedSerialExecutor) -> Void = {
+  guard let dispatchAsyncSwiftJobFunc else {
+    // We can't find the `dispatch_async_swift_job` method so let's fallback
+    return { queue, job, serialExecutor in
+      queue.async {
+        job.runSynchronously(on: serialExecutor)
+      }
+    }
+  }
+  return { queue, job, _ in
+    // Convert UnownedJob to a raw pointer for C interface
+    // Dispatch is storing this pointer after the call to enqueue as well so we
+    // cannot use a scoped with-style method here
+    let jobPointer = unsafeBitCast(job, to: UnsafeMutableRawPointer.self)
+    dispatchAsyncSwiftJobFunc(
+      queue,
+      jobPointer,
+      qosClassForPriority(job.priority).rawValue.rawValue
+    )
+  }
+}()
+
+// Cached global dispatch queues for performance using tuple for O(1) access
+private let globalQueues:
+  (
+    userInteractive: DispatchQueue,
+    userInitiated: DispatchQueue,
+    default: DispatchQueue,
+    utility: DispatchQueue,
+    background: DispatchQueue
+  ) = (
+    userInteractive: DispatchQueue.global(qos: .userInteractive),
+    userInitiated: DispatchQueue.global(qos: .userInitiated),
+    default: DispatchQueue.global(qos: .default),
+    utility: DispatchQueue.global(qos: .utility),
+    background: DispatchQueue.global(qos: .background)
+  )
+
+// Convert job priority to dispatch QoS class
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+private func qosClassForPriority(_ priority: JobPriority) -> DispatchQoS.QoSClass {
+  DispatchQoS.QoSClass(rawValue: .init(UInt32(priority.rawValue))) ?? .default
+}
+
+// Get cached global queue for priority with O(1) tuple access
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+private func getGlobalQueue(for priority: JobPriority) -> DispatchQueue {
+  switch qosClassForPriority(priority) {
+  case .userInteractive:
+    return globalQueues.userInteractive
+  case .userInitiated:
+    return globalQueues.userInitiated
+  case .default:
+    return globalQueues.default
+  case .utility:
+    return globalQueues.utility
+  case .background:
+    return globalQueues.background
+  default:
+    return globalQueues.default
+  }
+}
+
+// MARK: - Public Runtime Methods
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+internal func _dispatchMain() -> Never {
+  CPlatformExecutors_dispatchMain()
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+internal func _dispatchEnqueueMain(
+  _ job: UnownedJob,
+  serialExecutor: UnownedSerialExecutor
+) {
+  _enqueueJobOnSerialExecutor(DispatchQueue.main, job, serialExecutor)
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+internal func _dispatchAssertMainQueue() {
+  dispatchPrecondition(condition: .onQueue(.main))
+}
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+internal func _dispatchEnqueueGlobal(_ job: UnownedJob, taskExecutor: UnownedTaskExecutor) {
+  _enqueueJobOnTaskExecutor(getGlobalQueue(for: job.priority), job, taskExecutor)
+}
+#endif

--- a/Sources/PlatformExecutors/PlatformSerialExecutor.swift
+++ b/Sources/PlatformExecutors/PlatformSerialExecutor.swift
@@ -11,10 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 /// A platform-native task executor.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
 public final class PlatformSerialExecutor: SerialExecutor {
-  #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+  #if os(Linux) || os(Android) || os(FreeBSD)
   typealias Executor = PThreadSerialExecutor
+  #elseif canImport(Darwin)
+  typealias Executor = DispatchSerialExecutor
   #elseif os(Windows)
   // TODO: This is not the right type
   typealias Executor = Win32EventLoopExecutor

--- a/Sources/PlatformExecutors/PlatformTaskExecutor.swift
+++ b/Sources/PlatformExecutors/PlatformTaskExecutor.swift
@@ -11,10 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 /// A platform-native task executor.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
 public final class PlatformTaskExecutor: TaskExecutor {
-  #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+  #if os(Linux) || os(Android) || os(FreeBSD)
   typealias Executor = PThreadExecutor
+  #elseif canImport(Darwin)
+  typealias Executor = DispatchTaskExecutor
   #elseif os(Windows)
   // TODO: This is not the right type
   typealias Executor = Win32EventLoopExecutor

--- a/Sources/PlatformExecutors/PlatformTaskPoolExecutor.swift
+++ b/Sources/PlatformExecutors/PlatformTaskPoolExecutor.swift
@@ -11,10 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 /// A platform-native that distributes work across multiple threads.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
 public final class PlatformTaskPoolExecutor: TaskExecutor {
-  #if os(Linux) || os(Android) || os(FreeBSD) || canImport(Darwin)
+  #if os(Linux) || os(Android) || os(FreeBSD)
   typealias Executor = PThreadPoolExecutor
+  #elseif canImport(Darwin)
+  typealias Executor = DispatchTaskPoolExecutor
   #elseif os(Windows)
   typealias Executor = Win32ThreadPoolExecutor
   #endif


### PR DESCRIPTION
# Motivation

We need to provide the default executors on Darwin as well

# Modifications

This PR adds new Darwin executors based on Dispatch. Compared to the others those executors are not public though since folks on Darwin should use `DispatchQueue` directly.

# Result

We now have default executors for all platforms.