### PR TITLE
Implement `SchedulingExecutor` for `PThreadExecutor` on Linux

### DIFF
--- a/Sources/CPlatformExecutors/include/CPlatformExecutors.h
+++ b/Sources/CPlatformExecutors/include/CPlatformExecutors.h
@@ -16,6 +16,7 @@
 #ifdef __linux__
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
+#include <sys/timerfd.h>
 #include <pthread.h>
 #include <errno.h>
 

--- a/Sources/PlatformExecutors/Internal/PriorityQueue.swift
+++ b/Sources/PlatformExecutors/Internal/PriorityQueue.swift
@@ -104,7 +104,6 @@ struct PriorityQueue<T> {
   ///
   /// Returns: The next item in the queue, following the comparison
   ///          rule.
-  ///
   mutating func pop() -> T? {
     if storage.isEmpty {
       return nil
@@ -115,6 +114,18 @@ struct PriorityQueue<T> {
       downHeap(ndx: 0)
     }
     return result
+  }
+
+  /// Peek the highest priority item from the queue.
+  ///
+  /// If the comparison function is `>`, this will return the largest
+  /// item in the queue.  If the comparison function is `<`, it will
+  /// return the smallest.
+  ///
+  /// Returns: The next item in the queue, following the comparison
+  ///          rule.
+  func peek() -> T? {
+    return storage.first
   }
 
   /// Fix the heap condition by iterating upwards.

--- a/Sources/PlatformExecutors/Internal/UnownedJob+Compare.swift
+++ b/Sources/PlatformExecutors/Internal/UnownedJob+Compare.swift
@@ -41,6 +41,54 @@ func compareJobsByPriorityAndID(
   return lhs.priority > rhs.priority
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *)
+func compareJobsByContinuousClockInstantAndPriorityAndSequenceNumber(
+  lhs: (ContinuousClock.Instant, UnownedJob),
+  rhs: (ContinuousClock.Instant, UnownedJob),
+) -> Bool {
+  guard lhs.0 == rhs.0 else {
+    return lhs.0 < rhs.0
+  }
+
+  return compareJobsByPriorityAndSequenceNumber(lhs: lhs.1, rhs: rhs.1)
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+func compareJobsByContinuousClockInstantAndPriorityAndID(
+  lhs: (ContinuousClock.Instant, UnownedJob),
+  rhs: (ContinuousClock.Instant, UnownedJob),
+) -> Bool {
+  guard lhs.0 == rhs.0 else {
+    return lhs.0 < rhs.0
+  }
+
+  return compareJobsByPriorityAndID(lhs: lhs.1, rhs: rhs.1)
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999, *)
+func compareJobsBySuspendingClockInstantAndPriorityAndSequenceNumber(
+  lhs: (SuspendingClock.Instant, UnownedJob),
+  rhs: (SuspendingClock.Instant, UnownedJob),
+) -> Bool {
+  guard lhs.0 == rhs.0 else {
+    return lhs.0 < rhs.0
+  }
+
+  return compareJobsByPriorityAndSequenceNumber(lhs: lhs.1, rhs: rhs.1)
+}
+
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+func compareJobsBySuspendingClockInstantAndPriorityAndID(
+  lhs: (SuspendingClock.Instant, UnownedJob),
+  rhs: (SuspendingClock.Instant, UnownedJob),
+) -> Bool {
+  guard lhs.0 == rhs.0 else {
+    return lhs.0 < rhs.0
+  }
+
+  return compareJobsByPriorityAndID(lhs: lhs.1, rhs: rhs.1)
+}
+
 /// This is a method from the Concurrency ABI that we are using for fallback job ordering on older deployment
 /// targets
 @_silgen_name("swift_task_getJobTaskId")

--- a/Sources/PlatformExecutors/PThread/Internal/Selector/EpollSelector.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/Selector/EpollSelector.swift
@@ -27,45 +27,220 @@
 import Glibc
 import CPlatformExecutors
 
+/// A selector that uses epoll for eventing
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-struct EpollSelector {
+struct EpollSelector: ~Copyable {
+  /// User data supports (un)packing into an `UInt64` because epoll has a user info field that we can attach which is
+  /// up to 64 bits wide. We're using all of those 64 bits, 32 for a "registration ID" and 32 for the file descriptor.
+  struct UserData {
+    var registrationID: UInt32
+    var fileDescriptor: CInt
+
+    init(registrationID: UInt32, fileDescriptor: CInt) {
+      assert(MemoryLayout<UInt64>.size == MemoryLayout<UserData>.size)
+      self.registrationID = registrationID
+      self.fileDescriptor = fileDescriptor
+    }
+
+    init(rawValue: UInt64) {
+      let unpacked = IntegerBitPacking.unpackUInt32CInt(rawValue)
+      self = .init(registrationID: unpacked.0, fileDescriptor: unpacked.1)
+    }
+  }
+
+  /// The selector file descriptor.
   fileprivate var selectorFD: CInt
+  /// The event file descriptor to wake the thread when a new job is enqueued.
   fileprivate let eventFD: CInt
+  /// The monotonic timer file descriptor to back the suspending clock.
+  fileprivate let monotonicTimerFD: CInt
+  /// The boottime timer file descriptor to back the suspending clock.
+  fileprivate let boottimeTimerFD: CInt
+  /// The next continuous clock timer to avoid re-arming the timer if possible.
+  fileprivate var nextMonotonicClockTimer: ContinuousClock.Instant?
+  /// The next suspending clock timer to avoid re-arming the timer if possible.
+  fileprivate var nextBoottimelockTimer: SuspendingClock.Instant?
 
   init() throws {
-    self.selectorFD = try Epoll.epoll_create(size: 128)
-    self.eventFD = try EventFileDescriptor.makeEventFileDescriptor(
+    // We try! all of these since if the creation fails there is nothing we can do to recover.
+    self.selectorFD = try! Epoll.epoll_create(size: 128)
+    self.eventFD = try! EventFileDescriptor.makeEventFileDescriptor(
       initval: 0,
       flags: Int32(EventFileDescriptor.EFD_CLOEXEC | EventFileDescriptor.EFD_NONBLOCK)
+    )
+    self.monotonicTimerFD = try! TimerFileDescriptor.timerfd_create(
+      clockId: CLOCK_MONOTONIC,
+      flags: Int32(TimerFileDescriptor.TFD_CLOEXEC | TimerFileDescriptor.TFD_NONBLOCK)
+    )
+    self.boottimeTimerFD = try! TimerFileDescriptor.timerfd_create(
+      clockId: CLOCK_BOOTTIME,
+      flags: Int32(TimerFileDescriptor.TFD_CLOEXEC | TimerFileDescriptor.TFD_NONBLOCK)
     )
 
     var ev = Epoll.epoll_event()
     ev.events = Epoll.EPOLLERR | Epoll.EPOLLHUP | Epoll.EPOLLIN
+    ev.data.u64 = UInt64(
+      UserData(
+        registrationID: .max,
+        fileDescriptor: self.eventFD
+      )
+    )
     try Epoll.epoll_ctl(
       epfd: self.selectorFD,
       op: Epoll.EPOLL_CTL_ADD,
       fd: self.eventFD,
       event: &ev
     )
+
+    var monotonicTimerev = Epoll.epoll_event()
+    monotonicTimerev.events = Epoll.EPOLLIN | Epoll.EPOLLERR | Epoll.EPOLLRDHUP
+    monotonicTimerev.data.u64 = UInt64(
+      UserData(
+        registrationID: .max,
+        fileDescriptor: self.monotonicTimerFD
+      )
+    )
+    try Epoll.epoll_ctl(
+      epfd: self.selectorFD,
+      op: Epoll.EPOLL_CTL_ADD,
+      fd: self.monotonicTimerFD,
+      event: &monotonicTimerev
+    )
+
+    var boottimeTimerev = Epoll.epoll_event()
+    boottimeTimerev.events = Epoll.EPOLLIN | Epoll.EPOLLERR | Epoll.EPOLLRDHUP
+    boottimeTimerev.data.u64 = UInt64(
+      UserData(
+        registrationID: .max,
+        fileDescriptor: self.boottimeTimerFD
+      )
+    )
+    try Epoll.epoll_ctl(
+      epfd: self.selectorFD,
+      op: Epoll.EPOLL_CTL_ADD,
+      fd: self.boottimeTimerFD,
+      event: &boottimeTimerev
+    )
+  }
+
+  deinit {
+    // We try! all of the closes because close can only fail in the following ways:
+    // - EINTR, which we eat in close
+    // - EIO, which can only happen for on-disk files
+    // - EBADF, which can't happen here because we would crash as EBADF is marked unacceptable
+    // Therefore, we assert here that close will always succeed and if not, that's a bug we need to know
+    // about.
+    try! close(descriptor: self.boottimeTimerFD)
+    try! close(descriptor: self.monotonicTimerFD)
+    try! close(descriptor: self.eventFD)
+    try! close(descriptor: self.selectorFD)
   }
 
   /// Blocks until the wakeup is called.
-  func whenReady(
+  mutating func whenReady(
     strategy: SelectorStrategy
   ) throws {
+    // Right now we only handle three events at most: EventFD and two TimerFDs
+    let maxEvents = 3
 
-    _ = try withUnsafeTemporaryAllocation(of: Epoll.epoll_event.self, capacity: 1) { bufferPointer in
-      try Epoll.epoll_wait(
-        epfd: self.selectorFD,
-        events: bufferPointer.baseAddress!,
-        maxevents: 1,
-        timeout: -1  // Specifying -1 blocks until a file descriptor becomes ready
-      )
+    try withUnsafeTemporaryAllocation(of: Epoll.epoll_event.self, capacity: maxEvents) { eventsPointer in
+      let readyEvents: Int
+      switch strategy {
+      case .now:
+        readyEvents = Int(
+          try Epoll.epoll_wait(
+            epfd: self.selectorFD,
+            events: eventsPointer.baseAddress!,
+            maxevents: Int32(maxEvents),
+            timeout: 0
+          )
+        )
+      case .blockUntilTimeout(let continuousClockInstant, let suspendingClockInstant):
+        // The continuous clock maps to the boottime clock
+        func setTimer(instant: ContinuousClock.Instant) throws {
+          var ts = itimerspec()
+          ts.it_value = timespec(duration: ContinuousClock.now.duration(to: instant))
+          try TimerFileDescriptor.timerfd_settime(fd: self.boottimeTimerFD, flags: 0, newValue: &ts, oldValue: nil)
+        }
+        // The suspending clock maps to the monotonic clock
+        func setTimer(instant: SuspendingClock.Instant) throws {
+          var ts = itimerspec()
+          ts.it_value = timespec(duration: SuspendingClock.now.duration(to: instant))
+          try TimerFileDescriptor.timerfd_settime(fd: self.monotonicTimerFD, flags: 0, newValue: &ts, oldValue: nil)
+        }
+        // Only call timerfd_settime if we're not already scheduled one that will cover it.
+        if let continuousClockInstant {
+          if let nextMonotonicClockTimer = self.nextMonotonicClockTimer {
+            if continuousClockInstant < nextMonotonicClockTimer {
+              try setTimer(instant: continuousClockInstant)
+            }
+          } else {
+            try setTimer(instant: continuousClockInstant)
+          }
+        }
+
+        // Only call timerfd_settime if we're not already scheduled one that will cover it.
+        if let suspendingClockInstant {
+          if let nextBoottimelockTimer = self.nextBoottimelockTimer {
+            if suspendingClockInstant < nextBoottimelockTimer {
+              try setTimer(instant: suspendingClockInstant)
+            }
+          } else {
+            try setTimer(instant: suspendingClockInstant)
+          }
+        }
+        fallthrough
+
+      case .block:
+        readyEvents = Int(
+          try Epoll.epoll_wait(
+            epfd: self.selectorFD,
+            events: eventsPointer.baseAddress!,
+            maxevents: Int32(maxEvents),
+            timeout: -1  // Specifying -1 blocks until a file descriptor becomes ready
+          )
+        )
+      }
+
+      for i in 0..<readyEvents {
+        let ev = eventsPointer[i]
+        let epollUserData = UserData(rawValue: ev.data.u64)
+        let fd = epollUserData.fileDescriptor
+        _ = epollUserData.registrationID
+        switch fd {
+        case self.eventFD:
+          // Consume event
+          var val = EventFileDescriptor.eventfd_t()
+          _ = try EventFileDescriptor.eventfd_read(fd: self.eventFD, value: &val)
+        case self.monotonicTimerFD:
+          // Consume event
+          var val: UInt64 = 0
+          // We are not interested in the result
+          _ = try! TimerFileDescriptor.timerfd_read(
+            descriptor: self.monotonicTimerFD,
+            pointer: &val,
+            size: MemoryLayout.size(ofValue: val)
+          )
+
+          // Processed the earliest set timer so reset it.
+          self.nextMonotonicClockTimer = nil
+        case self.boottimeTimerFD:
+          // Consume event
+          var val: UInt64 = 0
+          // We are not interested in the result
+          _ = try! TimerFileDescriptor.timerfd_read(
+            descriptor: self.boottimeTimerFD,
+            pointer: &val,
+            size: MemoryLayout.size(ofValue: val)
+          )
+
+          // Processed the earliest set timer so reset it.
+          self.nextBoottimelockTimer = nil
+        default:
+          fatalError("Unknown file descriptor in epoll event")
+        }
+      }
     }
-
-    // Consume event
-    var val = EventFileDescriptor.eventfd_t()
-    _ = try EventFileDescriptor.eventfd_read(fd: self.eventFD, value: &val)
   }
 
   /// Wakes up the selector.
@@ -146,37 +321,6 @@ internal enum Epoll {
   }
 }
 
-private enum EventFileDescriptor {
-  fileprivate static let EFD_CLOEXEC = CPlatformExecutors.EFD_CLOEXEC
-  fileprivate static let EFD_NONBLOCK = CPlatformExecutors.EFD_NONBLOCK
-  fileprivate typealias eventfd_t = CPlatformExecutors.eventfd_t
-
-  @inline(never)
-  fileprivate static func eventfd_read(fd: CInt, value: UnsafeMutablePointer<UInt64>) throws -> CInt {
-    return try retryingSyscall(blocking: false) {
-      CPlatformExecutors.eventfd_read(fd, value)
-    }.result
-  }
-
-  @inline(never)
-  internal static func eventfd_write(fd: CInt, value: UInt64) throws -> CInt {
-    return try retryingSyscall(blocking: false) {
-      CPlatformExecutors.eventfd_write(fd, value)
-    }.result
-  }
-
-  @inline(never)
-  fileprivate static func makeEventFileDescriptor(initval: CUnsignedInt, flags: CInt) throws -> CInt {
-    return try retryingSyscall(blocking: false) {
-      // Note: Please do _not_ remove the `numericCast`, this is to allow compilation in Ubuntu 14.04 and
-      // other Linux distros which ship a glibc from before this commit:
-      // https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=69eb9a183c19e8739065e430758e4d3a2c5e4f1a
-      // which changes the first argument from `CInt` to `CUnsignedInt` (from Sat, 20 Sep 2014).
-      CPlatformExecutors.eventfd(numericCast(initval), flags)
-    }.result
-  }
-}
-
 private struct EpollFilterSet: OptionSet, Equatable {
   typealias RawValue = UInt8
 
@@ -191,6 +335,14 @@ private struct EpollFilterSet: OptionSet, Equatable {
 
   init(rawValue: RawValue) {
     self.rawValue = rawValue
+  }
+}
+
+extension UInt64 {
+  init(_ epollUserData: EpollSelector.UserData) {
+    let fd = epollUserData.fileDescriptor
+    assert(fd >= 0, "\(fd) is not a valid file descriptor")
+    self = IntegerBitPacking.packUInt32CInt(epollUserData.registrationID, fd)
   }
 }
 #endif

--- a/Sources/PlatformExecutors/PThread/Internal/Selector/EventFileDescriptor.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/Selector/EventFileDescriptor.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2017-2024 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Glibc)
+import Glibc
+import CPlatformExecutors
+
+enum EventFileDescriptor {
+  static let EFD_CLOEXEC = CPlatformExecutors.EFD_CLOEXEC
+  static let EFD_NONBLOCK = CPlatformExecutors.EFD_NONBLOCK
+  typealias eventfd_t = CPlatformExecutors.eventfd_t
+
+  @inline(never)
+  static func eventfd_read(fd: CInt, value: UnsafeMutablePointer<UInt64>) throws -> CInt {
+    return try retryingSyscall(blocking: false) {
+      CPlatformExecutors.eventfd_read(fd, value)
+    }.result
+  }
+
+  @inline(never)
+  internal static func eventfd_write(fd: CInt, value: UInt64) throws -> CInt {
+    return try retryingSyscall(blocking: false) {
+      CPlatformExecutors.eventfd_write(fd, value)
+    }.result
+  }
+
+  @inline(never)
+  static func makeEventFileDescriptor(initval: CUnsignedInt, flags: CInt) throws -> CInt {
+    return try retryingSyscall(blocking: false) {
+      // Note: Please do _not_ remove the `numericCast`, this is to allow compilation in Ubuntu 14.04 and
+      // other Linux distros which ship a glibc from before this commit:
+      // https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=69eb9a183c19e8739065e430758e4d3a2c5e4f1a
+      // which changes the first argument from `CInt` to `CUnsignedInt` (from Sat, 20 Sep 2014).
+      CPlatformExecutors.eventfd(numericCast(initval), flags)
+    }.result
+  }
+}
+#endif

--- a/Sources/PlatformExecutors/PThread/Internal/Selector/KQueueSelector.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/Selector/KQueueSelector.swift
@@ -28,12 +28,17 @@ import Darwin
 
 private let sysKevent = kevent
 
-@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-struct KQueueSelector {
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+struct KQueueSelector: ~Copyable {
+  /// The selector file descriptor.
   fileprivate var selectorFD: CInt
+  /// The next continuous clock timer to avoid re-arming the timer if possible.
+  fileprivate var nextContinuousClockTimer: ContinuousClock.Instant?
+  /// The next suspending clock timer to avoid re-arming the timer if possible.
+  fileprivate var nextSuspendingClockTimer: SuspendingClock.Instant?
 
   init() throws {
-    self.selectorFD = try Self.kqueue()
+    self.selectorFD = try! Self.kqueue()
 
     var event = Darwin.kevent()
     event.ident = 0
@@ -48,6 +53,16 @@ struct KQueueSelector {
         keventBuffer: UnsafeMutableBufferPointer(start: ptr, count: 1)
       )
     }
+  }
+
+  deinit {
+    // We try! all of the closes because close can only fail in the following ways:
+    // - EINTR, which we eat in close
+    // - EIO, which can only happen for on-disk files
+    // - EBADF, which can't happen here because we would crash as EBADF is marked unacceptable
+    // Therefore, we assert here that close will always succeed and if not, that's a bug we need to know
+    // about.
+    try! close(descriptor: self.selectorFD)
   }
 
   @inline(never)
@@ -104,26 +119,128 @@ struct KQueueSelector {
     switch strategy {
     case .block:
       return nil
+    case .blockUntilTimeout:
+      // Timer events will be handled by kqueue EVFILT_TIMER, so we block indefinitely
+      return nil
     case .now:
       return timespec(tv_sec: 0, tv_nsec: 0)
     }
   }
 
   /// Blocks until the wakeup is called.
-  func whenReady(
+  mutating func whenReady(
     strategy: SelectorStrategy
   ) throws {
+    // Set up timers if needed
+    try self.setupTimers(strategy: strategy)
+
     let timespec = Self.toKQueueTimeSpec(strategy: strategy)
-    _ = try timespec.withUnsafeOptionalPointer { ts in
-      Int(
-        try Self.kevent(
-          kq: self.selectorFD,
-          changelist: nil,
-          nchanges: 0,
-          eventlist: nil,
-          nevents: 0,
-          timeout: ts
+
+    // We need to handle timer events, so allocate space for events
+    let maxEvents = 3  // User event + 2 timer events
+    try withUnsafeTemporaryAllocation(of: Darwin.kevent.self, capacity: maxEvents) { eventsPointer in
+      let readyEvents = try timespec.withUnsafeOptionalPointer { ts in
+        Int(
+          try Self.kevent(
+            kq: self.selectorFD,
+            changelist: nil,
+            nchanges: 0,
+            eventlist: eventsPointer.baseAddress!,
+            nevents: CInt(maxEvents),
+            timeout: ts
+          )
         )
+      }
+
+      // Process the ready events
+      for i in 0..<readyEvents {
+        let event = eventsPointer[i]
+        switch Int16(event.filter) {
+        case Int16(EVFILT_USER):
+          // User wakeup event - nothing to do, just unblocks
+          break
+        case Int16(EVFILT_TIMER):
+          // Timer event - reset the corresponding timer state
+          switch Int(event.ident) {
+          case 1:
+            // Continuous clock timer fired
+            self.nextContinuousClockTimer = nil
+          case 2:
+            // Suspending clock timer fired
+            self.nextSuspendingClockTimer = nil
+          default:
+            fatalError("Unknown timer identifier in kqueue event: \(event.ident)")
+          }
+        default:
+          fatalError("Unknown filter type in kqueue event: \(event.filter)")
+        }
+      }
+    }
+  }
+
+  /// Set up kqueue timers for the given strategy
+  private mutating func setupTimers(strategy: SelectorStrategy) throws {
+    guard case .blockUntilTimeout(let continuousClockInstant, let suspendingClockInstant) = strategy else {
+      return
+    }
+
+    // Set up continuous clock timer (ident = 1)
+    if let continuousClockInstant {
+      let shouldSetTimer: Bool
+      if let nextContinuousClockTimer = self.nextContinuousClockTimer {
+        // Only set timer if new deadline is earlier
+        shouldSetTimer = continuousClockInstant < nextContinuousClockTimer
+      } else {
+        shouldSetTimer = true
+      }
+
+      if shouldSetTimer {
+        let duration = ContinuousClock.now.duration(
+          to: continuousClockInstant
+        )
+        let nanoseconds =
+          Int(duration.components.seconds) * 1_000_000_000 + Int(duration.components.attoseconds / 1_000_000_000)
+        try self.setTimer(ident: 1, nanoseconds: nanoseconds)
+        self.nextContinuousClockTimer = continuousClockInstant
+      }
+    }
+
+    // Set up suspending clock timer (ident = 2)
+    if let suspendingClockInstant {
+      let shouldSetTimer: Bool
+      if let nextSuspendingClockTimer = self.nextSuspendingClockTimer {
+        // Only set timer if new deadline is earlier
+        shouldSetTimer = suspendingClockInstant < nextSuspendingClockTimer
+      } else {
+        shouldSetTimer = true
+      }
+
+      if shouldSetTimer {
+        let duration = SuspendingClock.now.duration(
+          to: suspendingClockInstant
+        )
+        let nanoseconds =
+          Int(duration.components.seconds) * 1_000_000_000 + Int(duration.components.attoseconds / 1_000_000_000)
+        try self.setTimer(ident: 2, nanoseconds: nanoseconds)
+        self.nextSuspendingClockTimer = suspendingClockInstant
+      }
+    }
+  }
+
+  /// Set a kqueue timer for the given instant
+  private func setTimer(ident: Int, nanoseconds: Int) throws {
+    var event = Darwin.kevent()
+    event.ident = UInt(ident)
+    event.filter = Int16(EVFILT_TIMER)
+    event.flags = UInt16(EV_ADD | EV_ENABLE | EV_ONESHOT)
+    event.fflags = UInt32(NOTE_NSECONDS)
+    event.data = nanoseconds
+    event.udata = nil
+
+    try withUnsafeMutablePointer(to: &event) { ptr in
+      try Self.kqueueApplyEventChangeSet(
+        selectorFD: self.selectorFD,
+        keventBuffer: UnsafeMutableBufferPointer(start: ptr, count: 1)
       )
     }
   }

--- a/Sources/PlatformExecutors/PThread/Internal/Selector/_IntegerBitPacking.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/Selector/_IntegerBitPacking.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2021 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@usableFromInline
+enum _IntegerBitPacking {}
+
+extension _IntegerBitPacking {
+  @inlinable
+  static func packUU<
+    Left: FixedWidthInteger & UnsignedInteger,
+    Right: FixedWidthInteger & UnsignedInteger,
+    Result: FixedWidthInteger & UnsignedInteger
+  >(
+    _ left: Left,
+    _ right: Right,
+    type: Result.Type = Result.self
+  ) -> Result {
+    assert(MemoryLayout<Left>.size + MemoryLayout<Right>.size <= MemoryLayout<Result>.size)
+
+    let resultLeft = Result(left)
+    let resultRight = Result(right)
+    let result = (resultLeft << Right.bitWidth) | resultRight
+    assert(result.nonzeroBitCount == left.nonzeroBitCount + right.nonzeroBitCount)
+    return result
+  }
+
+  @inlinable
+  static func unpackUU<
+    Input: FixedWidthInteger & UnsignedInteger,
+    Left: FixedWidthInteger & UnsignedInteger,
+    Right: FixedWidthInteger & UnsignedInteger
+  >(
+    _ input: Input,
+    leftType: Left.Type = Left.self,
+    rightType: Right.Type = Right.self
+  ) -> (Left, Right) {
+    assert(MemoryLayout<Left>.size + MemoryLayout<Right>.size <= MemoryLayout<Input>.size)
+
+    let leftMask = Input(Left.max)
+    let rightMask = Input(Right.max)
+    let right = input & rightMask
+    let left = (input >> Right.bitWidth) & leftMask
+
+    assert(input.nonzeroBitCount == left.nonzeroBitCount + right.nonzeroBitCount)
+    return (Left(left), Right(right))
+  }
+}
+
+@usableFromInline
+enum IntegerBitPacking {}
+
+extension IntegerBitPacking {
+  @inlinable
+  static func packUInt32UInt16UInt8(_ left: UInt32, _ middle: UInt16, _ right: UInt8) -> UInt64 {
+    _IntegerBitPacking.packUU(
+      _IntegerBitPacking.packUU(right, middle, type: UInt32.self),
+      left
+    )
+  }
+
+  @inlinable
+  static func unpackUInt32UInt16UInt8(_ value: UInt64) -> (UInt32, UInt16, UInt8) {
+    let leftRight = _IntegerBitPacking.unpackUU(value, leftType: UInt32.self, rightType: UInt32.self)
+    let left = _IntegerBitPacking.unpackUU(leftRight.0, leftType: UInt8.self, rightType: UInt16.self)
+    return (leftRight.1, left.1, left.0)
+  }
+
+  @inlinable
+  static func packUInt8UInt8(_ left: UInt8, _ right: UInt8) -> UInt16 {
+    _IntegerBitPacking.packUU(left, right)
+  }
+
+  @inlinable
+  static func unpackUInt8UInt8(_ value: UInt16) -> (UInt8, UInt8) {
+    _IntegerBitPacking.unpackUU(value)
+  }
+
+  @inlinable
+  static func packUInt16UInt8(_ left: UInt16, _ right: UInt8) -> UInt32 {
+    _IntegerBitPacking.packUU(left, right)
+  }
+
+  @inlinable
+  static func unpackUInt16UInt8(_ value: UInt32) -> (UInt16, UInt8) {
+    _IntegerBitPacking.unpackUU(value)
+  }
+
+  @inlinable
+  static func packUInt32CInt(_ left: UInt32, _ right: CInt) -> UInt64 {
+    _IntegerBitPacking.packUU(left, UInt32(truncatingIfNeeded: right))
+  }
+
+  @inlinable
+  static func unpackUInt32CInt(_ value: UInt64) -> (UInt32, CInt) {
+    let unpacked = _IntegerBitPacking.unpackUU(value, leftType: UInt32.self, rightType: UInt32.self)
+    return (unpacked.0, CInt(truncatingIfNeeded: unpacked.1))
+  }
+
+  @inlinable
+  static func packUInt32UInt32(_ left: UInt32, _ right: UInt32) -> UInt64 {
+    _IntegerBitPacking.packUU(left, right)
+  }
+
+  @inlinable
+  static func unpackUInt32UInt32(_ value: UInt64) -> (UInt32, UInt32) {
+    let unpacked = _IntegerBitPacking.unpackUU(value, leftType: UInt32.self, rightType: UInt32.self)
+    return (unpacked.0, unpacked.1)
+  }
+
+  @inlinable
+  static func packUInt16UInt16(_ left: UInt16, _ right: UInt16) -> UInt32 {
+    _IntegerBitPacking.packUU(left, right)
+  }
+
+  @inlinable
+  static func unpackUInt16UInt16(_ value: UInt32) -> (UInt16, UInt16) {
+    let unpacked = _IntegerBitPacking.unpackUU(value, leftType: UInt16.self, rightType: UInt16.self)
+    return (unpacked.0, unpacked.1)
+  }
+}

--- a/Sources/PlatformExecutors/PThread/Internal/Selector/timespec+duration.swift
+++ b/Sources/PlatformExecutors/PThread/Internal/Selector/timespec+duration.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !os(Windows)
+import CPlatformExecutors
+
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+extension timespec {
+  init(duration: Duration) {
+    let nsecPerSec: Int64 = 1_000_000_000
+    let attosecondsPerNanosecond: Int64 = 1_000_000_000
+
+    // Convert attoseconds to nanoseconds
+    let totalNanoseconds = duration.components.attoseconds / attosecondsPerNanosecond
+
+    // Extract seconds and remaining nanoseconds
+    let seconds = totalNanoseconds / nsecPerSec
+    let nanoseconds = totalNanoseconds % nsecPerSec
+
+    self = timespec(
+      tv_sec: time_t(duration.components.seconds + seconds),
+      tv_nsec: Int(nanoseconds)
+    )
+  }
+}
+#endif

--- a/Sources/PlatformExecutors/PThread/PThreadSerialExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadSerialExecutor.swift
@@ -102,6 +102,23 @@ public final class PThreadSerialExecutor: SerialExecutor, @unchecked Sendable {
   }
 }
 
+#if !canImport(Darwin)
+extension PThreadSerialExecutor: SchedulingExecutor {
+  public var asSchedulingExecutor: SchedulingExecutor? {
+    return self
+  }
+
+  public func enqueue<C: Clock>(
+    _ job: consuming ExecutorJob,
+    at instant: C.Instant,
+    tolerance: C.Duration?,
+    clock: C
+  ) {
+    self.pThreadExecutor.enqueue(job, at: instant, tolerance: tolerance, clock: clock)
+  }
+}
+#endif
+
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PThreadSerialExecutor: CustomStringConvertible {
   public var description: String {

--- a/Sources/PlatformExecutors/PThread/PThreadTaskExecutor.swift
+++ b/Sources/PlatformExecutors/PThread/PThreadTaskExecutor.swift
@@ -141,6 +141,23 @@ public final class PThreadTaskExecutor: TaskExecutor {
   }
 }
 
+#if !canImport(Darwin)
+extension PThreadTaskExecutor: SchedulingExecutor {
+  public var asSchedulingExecutor: SchedulingExecutor? {
+    return self
+  }
+
+  public func enqueue<C: Clock>(
+    _ job: consuming ExecutorJob,
+    at instant: C.Instant,
+    tolerance: C.Duration?,
+    clock: C
+  ) {
+    self.next().enqueue(job, at: instant, tolerance: tolerance, clock: clock)
+  }
+}
+#endif
+
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension PThreadTaskExecutor: CustomStringConvertible {
   public var description: String {

--- a/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
+++ b/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
@@ -612,7 +612,7 @@ public final class Win32EventLoopExecutor: SerialExecutor, RunLoopExecutor, @unc
   #endif  // canImport(WinSDK)
 
   /// Return `self` as a `SchedulingExecutor`.
-  public var asSchedulable: SchedulingExecutor? {
+  public var asSchedulingExecutor: SchedulingExecutor? {
     return self
   }
 }
@@ -830,7 +830,7 @@ public final class Win32ThreadPoolExecutor: TaskExecutor, @unchecked Sendable {
   }
 
   /// Return `self` as a `SchedulingExecutor`.
-  public var asSchedulable: SchedulingExecutor? {
+  public var asSchedulingExecutor: SchedulingExecutor? {
     return self
   }
 }


### PR DESCRIPTION
# Motivation

Our executors should be capable of scheduling sleeps for the continuous and suspending clocks

# Modifications

This PR adds support to the `PThreadExecutor` when backed by the epoll selector to handle sleeps for both the continuous and suspending clocks. This is done by using the timer file descriptor support on Linux.

# Result

We can now handle clocks on our pthread based executor.