### PR TITLE
[Win32] Fix possible overflow.

### DIFF
--- a/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
+++ b/Sources/PlatformExecutors/Win32Executor/Win32NativeExecutors.swift
@@ -579,6 +579,11 @@ public final class Win32EventLoopExecutor: SerialExecutor, RunLoopExecutor, @unc
       return INFINITE
     }
 
+    // Make sure we don't overflow
+    if lowestDelta <= leeway {
+      return 0
+    }
+
     // Compute the desired fire time
     let fireTime = lowestDelta - leeway
 


### PR DESCRIPTION
Depending on timings, it's possible that `lowestDelta` might be less than `leeway`, and in that case we should just return 0 here.