### PR TITLE
[IO] Introduce experimental operation scheduler protocol

### DIFF
--- a/Sources/PlatformExecutors/IO/OperationRegistration.swift
+++ b/Sources/PlatformExecutors/IO/OperationRegistration.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if ExperimentalIO
+/// An opaque, stable, non-reused identity for one in-flight operation.
+public struct OperationRegistration: Sendable, Hashable {
+  /// The unique identifier for this registration.
+  public var id: UInt
+
+  /// Creates a new registration with the given identifier.
+  ///
+  /// - Parameter id: The unique identifier for this registration.
+  public init(id: UInt) {
+    self.id = id
+  }
+}
+#endif

--- a/Sources/PlatformExecutors/IO/OperationScheduler.swift
+++ b/Sources/PlatformExecutors/IO/OperationScheduler.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if ExperimentalIO
+/// A scheduler that can be used to perform operations.
+///
+/// This is the base protocol that any resource specific scheduler should inherit from.
+public protocol OperationScheduler: AnyObject {
+  /// Per-operation state passed to the resource specific submit methods.
+  associatedtype OperationState: ~Copyable
+
+  /// Performs the given operation.
+  ///
+  /// - Parameter registration: The registration of the operation.
+  func cancel(
+    _ registration: OperationRegistration
+  )
+
+  /// Performs the given operation.
+  ///
+  /// - Parameters:
+  ///   - registration: The registration of the operation.
+  ///   - newPriority: The new priority to set.
+  func escalatePriority(
+    of registration: OperationRegistration,
+    to newPriority: TaskPriority
+  )
+}
+#endif


### PR DESCRIPTION
Every I/O operation goes through the same lifecycle:
1. Allocating state needed for the operation
2. Submitting the operation to the scheduler
3. Suspending to wait for the completion
4. Optional: Cancel the operation
5. Optional: Escalate the priority of the operation

This PR introduces a new `OperationScheduler` protocol that defines the common lifecycle methods 1, 4, and 5 that any resource specific scheduler should inherit from. 2 is resource specific so it cannot life in this protocol. 3 is done by the caller that submits.

Tests will be added in a follow up PR when we introduce the first resource